### PR TITLE
Hayabusa2 conf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ release.
 ### Added
 - Adds support for LO [#11](https://github.com/DOI-USGS/SpiceQL/issues/11)
 - Adds support for Smart1 [#16](https://github.com/DOI-USGS/SpiceQL/issues/16)
+- Adds support for Hayabusa2 ONC [#12](https://github.com/DOI-USGS/SpiceQL/issues/12)
 
 ### Fixed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,7 @@ if(SPICEQL_BUILD_LIB)
                            ${CMAKE_CURRENT_SOURCE_DIR}/SpiceQL/db/cassini.json
                            ${CMAKE_CURRENT_SOURCE_DIR}/SpiceQL/db/clem1.json
                            ${CMAKE_CURRENT_SOURCE_DIR}/SpiceQL/db/galileo.json
+                           ${CMAKE_CURRENT_SOURCE_DIR}/SpiceQL/db/hayabusa2.json
                            ${CMAKE_CURRENT_SOURCE_DIR}/SpiceQL/db/juno.json
                            ${CMAKE_CURRENT_SOURCE_DIR}/SpiceQL/db/kaguya.json
                            ${CMAKE_CURRENT_SOURCE_DIR}/SpiceQL/db/lro.json

--- a/SpiceQL/db/hayabusa.json
+++ b/SpiceQL/db/hayabusa.json
@@ -36,7 +36,7 @@
         "ik": {
             "kernels": ["amica31.ti"]
         },
-        "deps" : ["hayabusa"]
+        "deps" : ["/hayabusa"]
     },
     "nirs": {
         "spk" : {
@@ -47,6 +47,6 @@
         "ik": {
             "kernels": ["nirs10.ti"]
         },
-        "deps" : ["hayabusa"]
+        "deps" : ["/hayabusa"]
     }
 }

--- a/SpiceQL/db/hayabusa2.json
+++ b/SpiceQL/db/hayabusa2.json
@@ -2,48 +2,30 @@
     "hayabusa2" : { 
         "ck" : { 
             "reconstructed" : { 
-                "kernels" : ["hayabusa_itokawarendezvous_v02n.bc$"]    
+                "kernels" : ["hyb2_.*_[0-9]{4}_v[0-9]{2}.bc"]    
             }
-        },
-        "dsk" : { 
-            "kernels" : ["hay_a_amica_5_itokawashape_v1_0_512q.bds$", "hay_a_amica_5_itokawashape_v1_0_64q.bds$"]
         },
         "fk" : { 
-            "kernels" : ["itokawa_fixed.tf$", "hayabusa_hp.tf$"]
-        },
-        "pck" : {
-            "reconstructed" : { 
-                "kernels" : ["itokawa_gaskell_n[0-9]{1}.tpc$"]
-            }
+            "kernels" : ["hyb2_v[0-9]{2}.tf$", "hyb2_ryugu_v[0-9]{2}.tf$", "hyb2_hp_v[0-9]{2}.tf$"]
         },
         "sclk" : { 
-            "kernels" : ["hayabusa.tsc$"]
+            "kernels" : ["hyb2_20141203-[0-9]{4}1231_v01.tsc$"]
         },
         "tspk" : { 
-            "kernels" : ["sb_25143_140.bsp$", "de403s.bsp$"]
+            "kernels" : ["de430.bsp$", "[0-9]{7}_ryugu_[0-9]{8}-[0-9]{8}_[0-9]{4}_[0-9]{8}.bsp$", "jup329.bsp", "sat375.bsp", "[0-9]{7}_Ryugu.bsp$", "[0-9]{7}_ryugu_[0-9]{8}-[0-9]{8}_[0-9]{4}_[0-9]{8}.bsp"]
         }
     },
-    "amica" : {
-        "ik" : { 
-            "kernels" : ["amica[0-9]{2}.ti$"]
-        }, 
+    "onc" : {
+        "ik" : {
+            "kernels" : ["hyb2_onc_v[0-9]{2}.ti$"]
+        },
         "iak" : {
-            "kernels" : ["amicaAddendum[0-9]{3}.ti$"]
+            "kernels" : ["hyb2oncAddendum[0-9]{4}.ti$"]
         },
-        "spk" : { 
-            "kernels" : ["hay_jaxa_050916_051119_v1n.bsp$", "hay_osbj_050911_051118_v1n.bsp$"]
-        },
-        "deps" : ["/hayabusa2"]
-    },
-    "nirs" : {
-        "ik" : { 
-            "kernels" : ["nirs[0-9]{2}.ti$"]
-        },  
-        "iak" : {
-            "kernels" : ["nirsAddendum[0-9]{3}.ti$"]
-        },
-        "spk" : { 
-            "kernels" : ["hay_jaxa_050916_051119_v1n.bsp$", "hayabusa_[0-9]{8}_[0-9]{8}_v[0-9]{2}.bsp$"]
+        "spk" : {
+            "reconstructed" : { 
+                "kernels" : ["hyb2_[0-9]{8}-[0-9]{8}_[0-9]{4}[a-z]{1}_final_ver[0-9]{1}.oem.bsp$", "hyb2_hpk_[0-9]{8}_[0-9]{8}_v[0-9]{2}.bsp$", "hyb2_approach_od_v[0-9]{14}.bsp","lidar_derived_trj_[0-9]{8}_[0-9]{14}_[0-9]{14}_v[0-9]{2}.bsp$"]
+            }
         },
         "deps" : ["/hayabusa2"]
     }

--- a/SpiceQL/tests/FunctionalTestsConfig.cpp
+++ b/SpiceQL/tests/FunctionalTestsConfig.cpp
@@ -16,7 +16,7 @@ using namespace SpiceQL;
 TEST_F(TestConfig, FunctionalTestConfigConstruct) {
   json megaConfig = testConfig.globalConf();
 
-  EXPECT_EQ(megaConfig.size(), 39);
+  EXPECT_EQ(megaConfig.size(), 65);
 }
 
 TEST_F(TestConfig, FunctionalTestConfigEval) {

--- a/SpiceQL/tests/FunctionalTestsConfig.cpp
+++ b/SpiceQL/tests/FunctionalTestsConfig.cpp
@@ -16,7 +16,7 @@ using namespace SpiceQL;
 TEST_F(TestConfig, FunctionalTestConfigConstruct) {
   json megaConfig = testConfig.globalConf();
 
-  EXPECT_EQ(megaConfig.size(), 64);
+  EXPECT_EQ(megaConfig.size(), 39);
 }
 
 TEST_F(TestConfig, FunctionalTestConfigEval) {

--- a/SpiceQL/tests/QueryTests.cpp
+++ b/SpiceQL/tests/QueryTests.cpp
@@ -599,3 +599,87 @@ TEST_F(IsisDataDirectory, FunctionalTestListMissionKernelsSmart1) {
   expected = {"SMART1_V1.TF"};
   CompareKernelSets(getKernelsAsVector(res.at("smart1").at("fk")), expected);
 }
+
+TEST_F(IsisDataDirectory, FunctionalTestListMissionKernelsHayabusa2) {
+  fs::path dbPath = getMissionConfigFile("hayabusa2");
+  
+  compareKernelSets("hayabusa2");
+  ifstream i(dbPath);
+  nlohmann::json conf = nlohmann::json::parse(i);
+
+  MockRepository mocks;
+  mocks.OnCallFunc(ls).Return(files);
+
+  nlohmann::json res = listMissionKernels("doesn't matter", conf);
+
+  set<string> kernels = getKernelsAsSet(res);
+
+  set<string> mission = missionMap.at("hayabusa2");
+  
+  vector<string> expected = { "hyb2_hk_2015_v01.bc",
+                              "hyb2_hk_2016_v02.bc",
+                              "hyb2_hkattrpt_2017_v02.bc",
+                              "hyb2_aocsc_2015_v01.bc",
+                              "hyb2_aocsc_2017_v02.bc",
+                              "hyb2_hkattrpt_2016_v02.bc",
+                              "hyb2_hk_2014_v01.bc",
+                              "hyb2_hk_2017_v02.bc",
+                              "hyb2_hk_2015_v02.bc",
+                              "hyb2_hkattrpt_2015_v02.bc",
+                              "hyb2_aocsc_2016_v02.bc",
+                              "hyb2_aocsc_2018_v02.bc",
+                              "hyb2_hkattrpt_2018_v02.bc",
+                              "hyb2_aocsc_2015_v02.bc",
+                              "hyb2_hk_2014_v02.bc",
+                              "hyb2_aocsc_2014_v02.bc",
+                              "hyb2_aocsc_2014_v01.bc"
+                            };
+  CompareKernelSets(getKernelsAsVector(res.at("hayabusa2").at("ck").at("reconstructed")), expected); 
+
+  expected = {"hyb2_v06.tf",
+              "hyb2_v14.tf",
+              "hyb2_v10.tf",
+              "hyb2_ryugu_v01.tf",
+              "hyb2_v09.tf",
+              "hyb2_hp_v01.tf"
+             };
+  CompareKernelSets(getKernelsAsVector(res.at("hayabusa2").at("fk")), expected); 
+
+  expected = {"2162173_ryugu_20180601-20191230_0060_20181221.bsp",
+              "sat375.bsp",
+              "jup329.bsp",
+              "de430.bsp",
+              "2162173_Ryugu.bsp"
+             };
+
+  CompareKernelSets(getKernelsAsVector(res.at("hayabusa2").at("tspk")), expected); 
+
+  expected = {"hyb2_20141203-20161231_v01.tsc",
+              "hyb2_20141203-20171231_v01.tsc",
+              "hyb2_20141203-20191231_v01.tsc"
+             };
+  CompareKernelSets(getKernelsAsVector(res.at("hayabusa2").at("sclk")), expected); 
+
+//@TODO lidar derived?
+  expected = { "lidar_derived_trj_20191114_20180630053224_20190213030000_v02.bsp",
+               "hyb2_20151123-20151213_0001m_final_ver1.oem.bsp",
+               "hyb2_20141203-20161119_0001h_final_ver1.oem.bsp",
+               "hyb2_20141203-20151231_0001h_final_ver1.oem.bsp",
+               "hyb2_20141203-20141214_0001m_final_ver1.oem.bsp",
+               "hyb2_hpk_20180627_20190213_v01.bsp",
+               "hyb2_approach_od_v20180811114238.bsp"
+             };
+  CompareKernelSets(getKernelsAsVector(res.at("onc").at("spk").at("reconstructed")), expected); 
+
+  expected = {"hyb2_onc_v00.ti",
+              "hyb2_onc_v05.ti"
+             };
+  CompareKernelSets(getKernelsAsVector(res.at("onc").at("ik")), expected); 
+
+  expected = {"hyb2oncAddendum0001.ti"};
+  CompareKernelSets(getKernelsAsVector(res.at("onc").at("iak")), expected); 
+
+
+
+}
+


### PR DESCRIPTION
Hayabusa2 configuration already existed, but I'm not sure where it came from.  It was not part of the cmakelists, and many portions of the configuration pointed to hayaubsa rather than hayabusa2.  Maybe I'm missing something, but I rewrote it / removed portions to better match the kernels listed for the hayabusa2 mission.

Closes #12 