### PR TITLE
Accept string for ets param

### DIFF
--- a/fastapi/app/main.py
+++ b/fastapi/app/main.py
@@ -1,8 +1,8 @@
 """Module providing SpiceQL endpoints"""
 
 from ast import literal_eval
-from typing import Annotated, Any
-from fastapi import FastAPI, Query
+from typing import Any
+from fastapi import FastAPI
 from pydantic import BaseModel, Field
 from starlette.responses import RedirectResponse
 import numpy as np
@@ -47,7 +47,7 @@ async def getTargetStates(
     frame: str,
     abcorr: str,
     mission: str,
-    ets: Annotated[list[float], Query()] | str | None = None,
+    ets: str = None,
     startEts: float | None = None,
     exposureDuration: float | None = None,
     numOfExposures: int | None = None,
@@ -76,7 +76,7 @@ async def getTargetOrientations(
     toFrame: int,
     refFrame: int,
     mission: str,
-    ets: Annotated[list[float], Query()] | str | None = None,
+    ets: str | None = None,
     startEts: float | None = None,
     exposureDuration: float | None = None,
     numOfExposures: int | None = None,


### PR DESCRIPTION
Updated the `ets` param for /getTargetOrientations and /getTargetStates to accept either string (assuming comma separated list of values) or `None`.  This fixes a bug where a list of values for `ets` turns into **/getTargetStates?ets=123&ets=456** and is not accepted in the endpoint's respective `pyspiceql` function that is called.