### PR TITLE
fixed bug where cks were using interval scope

### DIFF
--- a/SpiceQL/src/utils.cpp
+++ b/SpiceQL/src/utils.cpp
@@ -1000,6 +1000,8 @@ namespace SpiceQL {
 
 
   pair<double, double> getKernelStartStopTimes(string kpath) {
+    SPDLOG_TRACE("getKernelStartStopTimes({})", kpath);
+
     double start_time = 0;
     double stop_time = 0;
     
@@ -1013,6 +1015,7 @@ namespace SpiceQL {
 
       for(int j = 0;  j < niv;  j++) {
         //Get the endpoints of the jth interval.
+        SPDLOG_TRACE("Collecting start stop times");
         wnfetd_c(&coverage, j, &begin, &end);
         checkNaifErrors();
 
@@ -1076,6 +1079,7 @@ namespace SpiceQL {
           SPICEDOUBLE_CELL(cover, 300000);
           ssize_c(0, &cover);
           ssize_c(300000, &cover);
+          SPDLOG_TRACE("Getting spk coverage");
           spkcov_c(kpath.c_str(), body, &cover);
           getStartStopFromInterval(cover);
         }
@@ -1084,9 +1088,11 @@ namespace SpiceQL {
           SPICEDOUBLE_CELL(cover, 300000);
           ssize_c(0, &cover);
           ssize_c(300000, &cover);
+          SPDLOG_TRACE("Getting ck coverage");
 
           // A SPICE SEGMENT is composed of SPICE INTERVALS
-          ckcov_c(kpath.c_str(), body, SPICEFALSE, "INTERVAL", 0.0, "TDB", &cover);
+          ckcov_c(kpath.c_str(), body, SPICEFALSE, "SEGMENT", 0.0, "TDB", &cover);
+          SPDLOG_TRACE("collecting start stop times");
 
           getStartStopFromInterval(cover);
         }


### PR DESCRIPTION
Accidentally introduced this in #41 

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [ ] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

