### PR TITLE
fix for getLatestKernels 

### DIFF
--- a/SpiceQL/src/inventoryimpl.cpp
+++ b/SpiceQL/src/inventoryimpl.cpp
@@ -152,7 +152,7 @@ namespace SpiceQL {
       m_required_kernels.load(lsk_json); 
 
       for (auto &[mission, kernels] : json_kernels.items()) {
-        fmt::print("mission: {}\n", mission);    
+        SPDLOG_TRACE("MISSION: {}", mission);
 
         json sclk_json = getLatestKernels(config[mission].getRecursive("sclk")); 
         SPDLOG_TRACE("{} SCLKs: {}", mission, sclk_json.dump(4)); 

--- a/SpiceQL/src/query.cpp
+++ b/SpiceQL/src/query.cpp
@@ -70,6 +70,14 @@ namespace SpiceQL {
     }
   }
 
+  // Comparator function for kernel paths
+  bool fileNameComp(string a, string b) {
+      string fna = static_cast<fs::path>(a).filename();
+      string fnb = static_cast<fs::path>(b).filename();
+      int comp = fna.compare(fnb);  
+      SPDLOG_TRACE("Comparing {} and {}: {}", fna, fnb, comp);
+      return comp < 0;
+  }
 
   vector<string> getLatestKernel(vector<string> kernels) {
     if(kernels.empty()) {
@@ -88,17 +96,25 @@ namespace SpiceQL {
       }
       bool foundList = false;
       for (int i = 0; i < files.size(); i++) {
+        
         const fs::path &firstVecElem = files[i][0];
         string fileName = firstVecElem.filename();
         string kernelName = k.filename();
+        SPDLOG_TRACE("filename: {}", fileName); 
+        SPDLOG_TRACE("kernel name: {}", kernelName); 
+
         int findRes = fileName.find_first_of("0123456789");
         if (findRes != string::npos) {
           fileName = fileName.erase(findRes);
         }
+
         findRes = kernelName.find_first_of("0123456789");
         if (findRes != string::npos) {
           kernelName = kernelName.erase(findRes);
         }
+        SPDLOG_TRACE("Truncated filename: {}", fileName); 
+        SPDLOG_TRACE("Truncated kernel name: {}", kernelName); 
+
         if (fileName == kernelName) {
           files[i].push_back(k);
           foundList = true;
@@ -112,7 +128,8 @@ namespace SpiceQL {
 
     vector<string> outKernels = {};
     for (auto kernelList : files) {
-      outKernels.push_back(*(max_element(kernelList.begin(), kernelList.end())));
+      SPDLOG_TRACE("Max element: {}", *max_element(kernelList.begin(), kernelList.end(), fileNameComp));
+      outKernels.push_back(*(max_element(kernelList.begin(), kernelList.end(), fileNameComp)));
     }
 
     return outKernels;
@@ -120,11 +137,13 @@ namespace SpiceQL {
 
 
   json getLatestKernels(json kernels) {
-
+    SPDLOG_TRACE("Looking for kernels to get Latest: {}", kernels.dump(2));
     vector<json::json_pointer> kptrs = findKeyInJson(kernels, "kernels", true);
     vector<vector<string>> lastest;
 
     for (json::json_pointer &ptr : kptrs) {
+      SPDLOG_TRACE("Getting Latest Kernels from: {}", ptr.to_string());
+      SPDLOG_TRACE("JSON: {}", kernels[ptr]);
       vector<vector<string>> kvect = json2DArrayTo2DVector(kernels[ptr]);
       vector<vector<string>> newLatest;
  

--- a/SpiceQL/src/query.cpp
+++ b/SpiceQL/src/query.cpp
@@ -128,7 +128,6 @@ namespace SpiceQL {
 
     vector<string> outKernels = {};
     for (auto kernelList : files) {
-      SPDLOG_TRACE("Max element: {}", *max_element(kernelList.begin(), kernelList.end(), fileNameComp));
       outKernels.push_back(*(max_element(kernelList.begin(), kernelList.end(), fileNameComp)));
     }
 

--- a/SpiceQL/tests/QueryTests.cpp
+++ b/SpiceQL/tests/QueryTests.cpp
@@ -27,6 +27,27 @@ TEST(QueryTests, UnitTestGetLatestKernel) {
   EXPECT_EQ(getLatestKernel(kernels)[0],  "test/iak.0004.ti");
 }
 
+
+TEST(QueryTests, UnitTestGetLatestKernelDuplicateFileNames) {
+  vector<string> kernels = {
+                    "/base/kernels/spk/mar080.bsp",
+                    "/base/kernels/spk/mar097.bsp",
+                    "/mro/kernels/spk/mar063.bsp",
+                    "/odyssey/kernels/spk/mar063.bsp",
+                    "/tgo/kernels/spk/mar085.bsp",
+                    "/tgo/kernels/spk/mar097.bsp",
+                    "/tgo/kernels/tspk/mar085.bsp",
+                    "/tgo/kernels/tspk/mar097.bsp",
+                    "/viking1/kernels/spk/mar033.bsp",
+                    "/viking2/kernels/spk/mar033.bsp", 
+                    "/base/kernels/spk/mar097.bsp"
+  };
+
+  // which one doesn't matter, as long as we get mar097.bsp
+  EXPECT_EQ(static_cast<fs::path>(getLatestKernel(kernels)[0]).filename(),  "mar097.bsp");
+}
+
+
 TEST(QueryTests, getKernelStringValue){
   unique_ptr<Kernel> k(new Kernel("data/msgr_mdis_v010.ti"));
   // INS-236810_CCD_CENTER        =  (  511.5, 511.5 )


### PR DESCRIPTION
Fixes bug in get latest kernels where the lexical sort will fail depending on the path prefix. This adds a custom comparator that only checks the filenames rather than the absolute path.  


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [ ] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

