### PR TITLE
Bug fixes

### DIFF
--- a/.github/workflows/ci_testing.yml
+++ b/.github/workflows/ci_testing.yml
@@ -17,7 +17,7 @@ jobs:
       run:
         shell: bash -l {0}
     env:
-      SSPICE_DEBUG: y
+      SPICEQL_DEV_DB: True
       SPICEQL_LOG_LEVEL: DEBUG
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ cmake .. -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX
 
 # Optional: DB files are installed by default in $CONDA_PREFIX/etc/SpiceQL/db to 
 # use files that are included within the repo, you must create and define 
-# an environment variable named SSPICE_DEBUG. 
-# note SSPICE_DEBUG can be set to anything as long as it is defined
-export SSPICE_DEBUG=True
+# an environment variable named SPICEQL_DEV_DB. 
+# note SPICEQL_DEV_DB must be set to 'True'
+export SPICEQL_DEV_DB=True
 
 # Set the environment variable(s) to point to your kernel install 
 # The following environment variables are used by default in order of priority: 

--- a/SpiceQL/include/api.h
+++ b/SpiceQL/include/api.h
@@ -44,7 +44,7 @@ namespace SpiceQL {
      *
      * @return A vector of vectors with a Nx7 state vector of positions and velocities in x,y,z,vx,vy,vz format followed by the light time adjustment.
      **/
-    std::pair<std::vector<std::vector<double>>, nlohmann::json> getTargetStates(std::vector<double> ets, std::string target, std::string observer, std::string frame, std::string abcorr, std::string mission, std::vector<std::string> ckQualities={"smithed", "reconstructed"}, std::vector<std::string> spkQualities={"smithed", "reconstructed"}, bool useWeb=false, bool searchKernels=true, std::vector<std::string> kernel_list={});
+    std::pair<std::vector<std::vector<double>>, nlohmann::json> getTargetStates(std::vector<double> ets, std::string target, std::string observer, std::string frame, std::string abcorr, std::string mission, std::vector<std::string> ckQualities={"smithed", "reconstructed"}, std::vector<std::string> spkQualities={"smithed", "reconstructed"}, bool useWeb=false, bool searchKernels=true, std::vector<std::string> kernelList={});
     
     /**
      * @brief Gives quaternion and angular velocity for a given frame at a set of ephemeris times
@@ -65,7 +65,7 @@ namespace SpiceQL {
      *
      * @returns Vector of SPICE-style quaternions (w,x,y,z) and optional angular velocity (4 element without angular velocity, 7 element with)
      **/
-    std::pair<std::vector<std::vector<double>>, nlohmann::json> getTargetOrientations(std::vector<double> ets, int toFrame, int refFrame, std::string mission, std::vector<std::string> ckQualities={"smithed", "reconstructed"}, bool useWeb=false, bool searchKernels=true, std::vector<std::string> kernel_list={});
+    std::pair<std::vector<std::vector<double>>, nlohmann::json> getTargetOrientations(std::vector<double> ets, int toFrame, int refFrame, std::string mission, std::vector<std::string> ckQualities={"smithed", "reconstructed"}, bool useWeb=false, bool searchKernels=true, std::vector<std::string> kernelList={});
     
     /**
      * @brief Converts a given string spacecraft clock time to an ephemeris time
@@ -81,7 +81,7 @@ namespace SpiceQL {
      * @param kernelList vector<string> vector of additional kernels to load     
      * @return double
      */
-    std::pair<double, nlohmann::json> strSclkToEt(int frameCode, std::string sclk, std::string mission, bool useWeb=false, bool searchKernels=true, std::vector<std::string> kernel_list={});
+    std::pair<double, nlohmann::json> strSclkToEt(int frameCode, std::string sclk, std::string mission, bool useWeb=false, bool searchKernels=true, std::vector<std::string> kernelList={});
 
     /**
      * @brief Converts a given double spacecraft clock time to an ephemeris time
@@ -97,7 +97,7 @@ namespace SpiceQL {
      * @param kernelList vector<string> vector of additional kernels to load 
      * @return double
      */
-    std::pair<double, nlohmann::json> doubleSclkToEt(int frameCode, double sclk, std::string mission, bool useWeb=false, bool searchKernels=true, std::vector<std::string> kernel_list={});
+    std::pair<double, nlohmann::json> doubleSclkToEt(int frameCode, double sclk, std::string mission, bool useWeb=false, bool searchKernels=true, std::vector<std::string> kernelList={});
 
 
     /**
@@ -127,7 +127,7 @@ namespace SpiceQL {
      * @param searchKernels bool Whether to search the kernels for the user
      * @returns double precision ephemeris time
      **/
-    std::pair<double, nlohmann::json> utcToEt(std::string utc, bool useWeb=false, bool searchKernels=true, std::vector<std::string> kernel_list={});
+    std::pair<double, nlohmann::json> utcToEt(std::string utc, bool useWeb=false, bool searchKernels=true, std::vector<std::string> kernelList={});
 
     /**
      * @brief convert et string to a UTC string
@@ -142,7 +142,7 @@ namespace SpiceQL {
      *
      * @returns double precision ephemeris time
      **/
-    std::pair<std::string, nlohmann::json> etToUtc(double et, std::string format, double precision, bool useWeb=false, bool searchKernels=true, std::vector<std::string> kernel_list={});
+    std::pair<std::string, nlohmann::json> etToUtc(double et, std::string format, double precision, bool useWeb=false, bool searchKernels=true, std::vector<std::string> kernelList={});
 
     /**
      * @brief Switch between NAIF frame string name to integer frame code
@@ -156,7 +156,7 @@ namespace SpiceQL {
      * 
      * @return integer Naif frame code
      **/
-    std::pair<int, nlohmann::json> translateNameToCode(std::string frame, std::string mission, bool useWeb=false, bool searchKernels=true, std::vector<std::string> kernel_list={});
+    std::pair<int, nlohmann::json> translateNameToCode(std::string frame, std::string mission, bool useWeb=false, bool searchKernels=true, std::vector<std::string> kernelList={});
 
     /**
      * @brief Switch between NAIF frame integer code to string frame name
@@ -170,7 +170,7 @@ namespace SpiceQL {
      *
      * @return string Naif frame name
      **/
-    std::pair<std::string, nlohmann::json> translateCodeToName(int frame, std::string mission, bool useWeb=false, bool searchKernels=true, std::vector<std::string> kernel_list={});
+    std::pair<std::string, nlohmann::json> translateCodeToName(int frame, std::string mission, bool useWeb=false, bool searchKernels=true, std::vector<std::string> kernelList={});
 
     /**
      * @brief Get the center, class id, and class of a given frame
@@ -184,7 +184,7 @@ namespace SpiceQL {
      *
      * @return 3 element vector of the given frames center, class id, and class
      **/
-    std::pair<std::vector<int>, nlohmann::json> getFrameInfo(int frame, std::string mission, bool useWeb=false, bool searchKernels=true, std::vector<std::string> kernel_list={});
+    std::pair<std::vector<int>, nlohmann::json> getFrameInfo(int frame, std::string mission, bool useWeb=false, bool searchKernels=true, std::vector<std::string> kernelList={});
 
      /**
     * @brief returns frame name and frame code associated to the target ID.
@@ -198,7 +198,7 @@ namespace SpiceQL {
     * 
     * @returns json of frame name and frame code
     **/
-    std::pair<nlohmann::json, nlohmann::json> getTargetFrameInfo(int targetId, std::string mission, bool useWeb=false, bool searchKernels=true, std::vector<std::string> kernel_list={});
+    std::pair<nlohmann::json, nlohmann::json> getTargetFrameInfo(int targetId, std::string mission, bool useWeb=false, bool searchKernels=true, std::vector<std::string> kernelList={});
 
     /**
     * @brief returns kernel values for a specific mission in the form of a json
@@ -210,7 +210,7 @@ namespace SpiceQL {
     * @param searchKernels bool Whether to search the kernels for the user
     * @returns json of values
     **/
-    std::pair<nlohmann::json, nlohmann::json> findMissionKeywords(std::string key, std::string mission, bool useWeb=false, bool searchKernels=true, std::vector<std::string> kernel_list={});
+    std::pair<nlohmann::json, nlohmann::json> findMissionKeywords(std::string key, std::string mission, bool useWeb=false, bool searchKernels=true, std::vector<std::string> kernelList={});
 
     /**
     * @brief returns Target values in the form of a vector
@@ -225,7 +225,7 @@ namespace SpiceQL {
     *
     * @returns vector of values
     **/
-    std::pair<nlohmann::json, nlohmann::json> findTargetKeywords(std::string key, std::string mission, bool useWeb=false, bool searchKernels=true, std::vector<std::string> kernel_list={});
+    std::pair<nlohmann::json, nlohmann::json> findTargetKeywords(std::string key, std::string mission, bool useWeb=false, bool searchKernels=true, std::vector<std::string> kernelList={});
 
     /**
      * @brief Given an ephemeris time and a starting frame, find the path from that starting frame to J2000 (1)
@@ -243,7 +243,7 @@ namespace SpiceQL {
      * @returns A two element vector of vectors ints, where the first element is the sequence of time dependent frames
      * and the second is the sequence of constant frames
      **/
-    std::pair<std::vector<std::vector<int>>, nlohmann::json> frameTrace(double et, int initialFrame, std::string mission, std::vector<std::string> ckQualities={"smithed", "reconstructed"}, bool useWeb=false, bool searchKernels=true, std::vector<std::string> kernel_list={});
+    std::pair<std::vector<std::vector<int>>, nlohmann::json> frameTrace(double et, int initialFrame, std::string mission, std::vector<std::string> ckQualities={"smithed", "reconstructed"}, bool useWeb=false, bool searchKernels=true, std::vector<std::string> kernelList={});
 
     /**
      * @brief Extracts all segment times between observStart and observeEnd
@@ -260,5 +260,5 @@ namespace SpiceQL {
      *
      * @returns A list of times
      **/
-    std::pair<std::vector<double>, nlohmann::json> extractExactCkTimes(double observStart, double observEnd, int targetFrame, std::string mission, std::vector<std::string> ckQualities={"smithed", "reconstructed"}, bool useWeb=false, bool searchKernels=true, std::vector<std::string> kernel_list={});
+    std::pair<std::vector<double>, nlohmann::json> extractExactCkTimes(double observStart, double observEnd, int targetFrame, std::string mission, std::vector<std::string> ckQualities={"smithed", "reconstructed"}, bool useWeb=false, bool searchKernels=true, std::vector<std::string> kernelList={});
 }

--- a/SpiceQL/include/utils.h
+++ b/SpiceQL/include/utils.h
@@ -226,7 +226,7 @@ namespace SpiceQL {
    * 
    * Default behavior returns the installed DB files in $CONDA_PREFIX/etc/SpiceQL/db.
    *
-   * If the env var $SSPICE_DEBUG is set, this returns the local source path of 
+   * If the env var $SPICEQL_DEV_DB is set, this returns the local source path of 
    * _SOURCE_PREFIX/SpiceQL/db/ 
    * 
    * @return std::string directory containing db files
@@ -238,7 +238,7 @@ namespace SpiceQL {
    * @brief Returns a vector of all the available configs
    * 
    * Returns the db files in either the installed or debug directory depending 
-   * on whether or not SSPICE_DEBUG is set. 
+   * on whether or not SPICEQL_DEV_DB is set. 
    *
    * @see getConfigDirectory
    *
@@ -251,7 +251,7 @@ namespace SpiceQL {
    * @brief Get names of available config files as a json vector
    *
    * This iterates through all the configs in the db folder either installed 
-   * or in the debug directory depending on whether or not SSPICE_DEBUG is set. Loads them 
+   * or in the debug directory depending on whether or not SPICEQL_DEV_DB is set. Loads them 
    * as vector of json obects and returns the vector. 
    *
    * @return std::vector<nlohmann::json> 

--- a/SpiceQL/src/api.cpp
+++ b/SpiceQL/src/api.cpp
@@ -13,7 +13,6 @@
 #include <nlohmann/json.hpp>
 #include <spdlog/spdlog.h>
 
-#include "config.h"
 #include "query.h"
 #include "spice_types.h"
 #include "utils.h"
@@ -373,7 +372,6 @@ namespace SpiceQL {
    pair<string, json> doubleEtToSclk(int frameCode, double et, string mission, bool useWeb, bool searchKernels, vector<string> kernelList) {
         SPDLOG_TRACE("calling strSclkToEt({}, {}, {}, {}, {}, {})", frameCode, et, mission, useWeb, searchKernels, kernelList.size());
 
-        Config missionConf;
         json ephemKernels;
        
         try {
@@ -480,8 +478,6 @@ namespace SpiceQL {
             SPDLOG_DEBUG("Could not get a successful response from the web API.");
         }
 
-        Config conf;
-        conf = conf["base"];
         json lsks = {};
 
         // get lsk kernel
@@ -525,8 +521,6 @@ namespace SpiceQL {
             SPDLOG_DEBUG("Could not get a successful response from the web API.");
         }
 
-        Config conf;
-        conf = conf["base"];
         json lsks = {};
 
         // get lsk kernel

--- a/SpiceQL/src/api.cpp
+++ b/SpiceQL/src/api.cpp
@@ -152,7 +152,7 @@ namespace SpiceQL {
     json spiceAPIQuery(std::string functionName, json args, std::string method){
         restincurl::Client client;
         // Need to be able to set URL externally
-        std::string queryString = "http://127.0.0.1:8080/" + functionName + "?";
+        std::string queryString = getRestUrl()+ functionName + "?";
 
         json j;
 

--- a/SpiceQL/src/api.cpp
+++ b/SpiceQL/src/api.cpp
@@ -370,7 +370,7 @@ namespace SpiceQL {
 
 
    pair<string, json> doubleEtToSclk(int frameCode, double et, string mission, bool useWeb, bool searchKernels, vector<string> kernelList) {
-        SPDLOG_TRACE("calling strSclkToEt({}, {}, {}, {}, {}, {})", frameCode, et, mission, useWeb, searchKernels, kernelList.size());
+        SPDLOG_TRACE("calling doubleEtToSclk({}, {}, {}, {}, {}, {})", frameCode, et, mission, useWeb, searchKernels, kernelList.size());
 
         json ephemKernels;
 

--- a/SpiceQL/src/api.cpp
+++ b/SpiceQL/src/api.cpp
@@ -152,7 +152,7 @@ namespace SpiceQL {
     json spiceAPIQuery(std::string functionName, json args, std::string method){
         restincurl::Client client;
         // Need to be able to set URL externally
-        std::string queryString = getRestUrl()+ functionName + "?";
+        std::string queryString = getRestUrl() + functionName + "?";
 
         json j;
 

--- a/SpiceQL/src/api.cpp
+++ b/SpiceQL/src/api.cpp
@@ -486,12 +486,12 @@ namespace SpiceQL {
 
         // get lsk kernel
         if (searchKernels) {
-        lsks = conf.getLatest("lsk");
+            lsks = Inventory::search_for_kernelset("base", {"lsk"});
         }
         if (!kernelList.empty()) {
-        json regexk = Inventory::search_for_kernelset_from_regex(kernelList);
-        // merge them into the ephem kernels overwriting anything found in the query
-        merge_json(lsks, regexk);
+            json regexk = Inventory::search_for_kernelset_from_regex(kernelList);
+            // merge them into the ephem kernels overwriting anything found in the query
+            merge_json(lsks, regexk);
         }
         
         KernelSet lsk(lsks);
@@ -531,12 +531,12 @@ namespace SpiceQL {
 
         // get lsk kernel
         if (searchKernels) {
-        lsks = Inventory::search_for_kernelset("base", {"lsk"});
+            lsks = Inventory::search_for_kernelset("base", {"lsk"});
         }
         if (!kernelList.empty()) {
-        json regexk = Inventory::search_for_kernelset_from_regex(kernelList);
-        // merge them into the ephem kernels overwriting anything found in the query
-        merge_json(lsks, regexk);
+            json regexk = Inventory::search_for_kernelset_from_regex(kernelList);
+            // merge them into the ephem kernels overwriting anything found in the query
+            merge_json(lsks, regexk);
         }
 
         KernelSet lsk(lsks);

--- a/SpiceQL/src/api.cpp
+++ b/SpiceQL/src/api.cpp
@@ -135,7 +135,7 @@ namespace SpiceQL {
                 escaped << c;
                 continue;
             }
-            
+
             if (c == '"'){
                 continue;
             }
@@ -375,7 +375,7 @@ namespace SpiceQL {
         }
 
         if (searchKernels) {
-          ephemKernels = Inventory::search_for_kernelsets({"base", "mission"}, {"fk", "lsk", "sclk"}); 
+          ephemKernels = Inventory::search_for_kernelsets({"base", mission}, {"fk", "lsk", "sclk"}); 
         }
 
         if (!kernelList.empty()) {
@@ -426,7 +426,7 @@ namespace SpiceQL {
         json sclks;
 
         if (searchKernels) {
-            sclks = Inventory::search_for_kernelset(mission, {"lsk", "fk", "sclk"});
+            sclks = Inventory::search_for_kernelsets({"base", mission}, {"lsk", "fk", "sclk"});
         }
 
         if (!kernelList.empty()) {
@@ -580,7 +580,7 @@ namespace SpiceQL {
                 {"searchKernels", searchKernels},
                 {"kernelList", kernelList}
             });
-            json out = spiceAPIQuery("translateCodeToame", args);
+            json out = spiceAPIQuery("translateCodeToName", args);
             string result = out["body"]["return"].get<string>();
             return make_pair(result, out["body"]["kernels"]);
         }

--- a/SpiceQL/src/utils.cpp
+++ b/SpiceQL/src/utils.cpp
@@ -1144,12 +1144,19 @@ namespace SpiceQL {
   string getConfigDirectory() {
     // If running tests or debugging locally
     char* condaPrefix = std::getenv("CONDA_PREFIX");
+    SPDLOG_TRACE("CONDA_PREFIX: {}", string(condaPrefix));
 
     fs::path debugDbPath = fs::absolute(_SOURCE_PREFIX) / "SpiceQL" / "db";
     fs::path installDbPath = fs::absolute(condaPrefix) / "etc" / "SpiceQL" / "db";
 
-    // Use installDbPath unless $SSPICE_DEBUG is set
-    fs::path dbPath = std::getenv("SSPICE_DEBUG") ? debugDbPath : installDbPath;
+    // Use installDbPath unless $SPICEQL_DEV_DB is set
+    fs::path dbPath;
+    if (std::getenv("SPICEQL_DEV_DB") && toLower(string(std::getenv("SPICEQL_DEV_DB"))) == "true") {
+      dbPath = debugDbPath; 
+    } else {
+      dbPath = installDbPath;
+    }
+    SPDLOG_TRACE("SpiceQL DB Path: {}", dbPath.string()); 
 
     if (!fs::is_directory(dbPath)) {
       throw runtime_error("Config Directory Not Found.");

--- a/environment.yml
+++ b/environment.yml
@@ -1,5 +1,4 @@
 channels:
-  - defaults
   - conda-forge
   - usgs-astrogeology
  

--- a/fastapi/README.md
+++ b/fastapi/README.md
@@ -9,7 +9,7 @@ conda env update -n spiceql-api -f environment.yaml
 ```
 
 ### 2. Set environment variables
-Similarly to your SpiceQL conda environment, set `SPICEROOT` or `ISISDATA` to your ISIS data area. You may also need to set `SSPICE_DEBUG` to any value, like `True`.
+Similarly to your SpiceQL conda environment, set `SPICEROOT` or `ISISDATA` to your ISIS data area. You may also need to set `SPICEQL_DEV_DB` to `True`.
 
 To set an environment variable within the scope of your conda environment:
 ```


### PR DESCRIPTION
Changes made:
- Renamed kernel_list to kernelList in api.h
- Added getRestUrl() functionality to use envvar `SPICEQL_REST_URL` if set
- Handle exceptions for when useWeb is true
- Removed duplicate kernel type searches in getTargetStates() and getTargetOrientations()
- Fixed doubleSclkToEt() to include "base" as a kernelset to search through
- Updated utcToEt() to use search_for_kernelset() instead of old conf.getLatest() method
- Removed duplicate findMissionKeywords() function
- Updated getConfigDirectory() to expect `SPICEQL_DEV_DB` instead of `SSPICE_DEBUG`
- Removed 'defaults' channel in environment.yml
- Replace `SSPICE_DEBUG` with `SPICEQL_DEV_DB` and updated docs to affirm that `SPICEQL_DEV_DB` must be set to "True" to be used (not like previously where it could be set to anything) 

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

