### PR TITLE
FIX: If statement preventing multiple SPK files to be loaded removed 

### DIFF
--- a/SpiceQL/src/inventoryimpl.cpp
+++ b/SpiceQL/src/inventoryimpl.cpp
@@ -368,7 +368,6 @@ namespace SpiceQL {
               SPDLOG_TRACE("Is {} with stop time {} in the array? {}", time_indices->file_paths.at(it->second), it->first, start_time_kernels.contains(it->second)); 
               if (start_time_kernels.contains(it->second)) {
                 final_time_kernels.push_back(time_indices->file_paths.at(it->second));
-                if (type == Kernel::Type::SPK) break;
               }
             } 
           }


### PR DESCRIPTION
Possibly a fix for an issue we are seeing in ISIS where the wrong SPK is prioritized. 


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [ ] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

