### PR TITLE
Fix `TSPK` ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ release.
 ### Fixed
 - Fixed default SpiceQL REST URL [#63](https://github.com/DOI-USGS/SpiceQL/pull/63)
 - Added missing db files (dawn, mariner10, near, and rosetta) to CMakeLists.txt [#69](https://github.com/DOI-USGS/SpiceQL/pull/69)
+- Fixed ordering of `tspks` when dependencies are merged within the database structures [#65](https://github.com/DOI-USGS/SpiceQL/pull/65)
 
 ## 1.0.1
 

--- a/SpiceQL/src/api.cpp
+++ b/SpiceQL/src/api.cpp
@@ -1,5 +1,6 @@
 #include <exception>
 #include <fstream>
+#include <sstream>
 
 #include <SpiceUsr.h>
 #include <SpiceZfc.h>

--- a/SpiceQL/src/utils.cpp
+++ b/SpiceQL/src/utils.cpp
@@ -160,10 +160,10 @@ namespace SpiceQL {
           }
 
           if (it.value().is_array()) {
-            baseConfig[it.key()].insert(baseConfig[it.key()].end(), it.value().begin(), it.value().end());
+            baseConfig[it.key()].insert(baseConfig[it.key()].begin(), it.value().begin(), it.value().end());
           }
           else {
-            baseConfig[it.key()] += it.value();
+            baseConfig[it.key()].insert(baseConfig[it.key()].begin(), it.value());
           }
         }
       }

--- a/SpiceQL/tests/UtilTests.cpp
+++ b/SpiceQL/tests/UtilTests.cpp
@@ -96,7 +96,7 @@ TEST(UtilTests, resolveConfigDependencies) {
     },
     "bad_nested_key" : "bad_value",
     "nested_key" : {
-      "value_key" : ["value_2", "value_1"]
+      "value_key" : ["value_1", "value_2"]
     }
   })"_json;
   EXPECT_EQ(resolvedConfig, expectedConfig);
@@ -167,10 +167,10 @@ TEST(UtilTests, mergeConfigs) {
         "kernels" : "predict_ck_1.bc"
       },
       "reconstructed" : {
-        "kernels" : ["recon_ck_3.bs", "recon_ck_1.bc", "recon_ck_2.bc"]
+        "kernels" : ["recon_ck_1.bc","recon_ck_2.bc","recon_ck_3.bs"]
       },
       "smithed" : {
-        "kernels" : ["smithed_ck_2.bs", "smithed_ck_3.bs", "smithed_ck_1.bs"]
+        "kernels" : ["smithed_ck_1.bs","smithed_ck_2.bs","smithed_ck_3.bs"]
       }
     },
     "spk" : {


### PR DESCRIPTION
Fixes the ordering of `tspks` when combining dependent config elements. This was an issue when getting `mars` from the base config.

SpiceQL would furnish the `mars` specific kernel first, then the generic kernel overriding the `mars` specific `tspk`

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

