### PR TITLE
Add missing db files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,7 @@ if(SPICEQL_BUILD_LIB)
                            ${CMAKE_CURRENT_SOURCE_DIR}/SpiceQL/db/cassini.json
                            ${CMAKE_CURRENT_SOURCE_DIR}/SpiceQL/db/chandrayaan1.json
                            ${CMAKE_CURRENT_SOURCE_DIR}/SpiceQL/db/clem1.json
+                           ${CMAKE_CURRENT_SOURCE_DIR}/SpiceQL/db/dawn.json
                            ${CMAKE_CURRENT_SOURCE_DIR}/SpiceQL/db/galileo.json
                            ${CMAKE_CURRENT_SOURCE_DIR}/SpiceQL/db/hayabusa.json
                            ${CMAKE_CURRENT_SOURCE_DIR}/SpiceQL/db/hayabusa2.json
@@ -101,6 +102,7 @@ if(SPICEQL_BUILD_LIB)
                            ${CMAKE_CURRENT_SOURCE_DIR}/SpiceQL/db/kaguya.json
                            ${CMAKE_CURRENT_SOURCE_DIR}/SpiceQL/db/lro.json
                            ${CMAKE_CURRENT_SOURCE_DIR}/SpiceQL/db/lo.json
+                           ${CMAKE_CURRENT_SOURCE_DIR}/SpiceQL/db/mariner10.json
                            ${CMAKE_CURRENT_SOURCE_DIR}/SpiceQL/db/mer1.json
                            ${CMAKE_CURRENT_SOURCE_DIR}/SpiceQL/db/mer2.json
                            ${CMAKE_CURRENT_SOURCE_DIR}/SpiceQL/db/mess.json
@@ -108,8 +110,10 @@ if(SPICEQL_BUILD_LIB)
                            ${CMAKE_CURRENT_SOURCE_DIR}/SpiceQL/db/mgs.json
                            ${CMAKE_CURRENT_SOURCE_DIR}/SpiceQL/db/mro.json
                            ${CMAKE_CURRENT_SOURCE_DIR}/SpiceQL/db/msl.json
+                           ${CMAKE_CURRENT_SOURCE_DIR}/SpiceQL/db/near.json
                            ${CMAKE_CURRENT_SOURCE_DIR}/SpiceQL/db/newhorizons.json
                            ${CMAKE_CURRENT_SOURCE_DIR}/SpiceQL/db/odyssey.json
+                           ${CMAKE_CURRENT_SOURCE_DIR}/SpiceQL/db/rosetta.json
                            ${CMAKE_CURRENT_SOURCE_DIR}/SpiceQL/db/smart1.json
                            ${CMAKE_CURRENT_SOURCE_DIR}/SpiceQL/db/tgo.json
                            ${CMAKE_CURRENT_SOURCE_DIR}/SpiceQL/db/viking1.json


### PR DESCRIPTION
Missing database files were added to CMakeLists.txt file: `dawn`, `mariner10`, `near`, and `rosetta`.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

