### PR TITLE
Add searchForKernelsets endpoint

### DIFF
--- a/fastapi/app/main.py
+++ b/fastapi/app/main.py
@@ -9,6 +9,7 @@ import os
 import pyspiceql
 import logging
 import h5py
+import sys
 
 logger = logging.getLogger('uvicorn.error')
 
@@ -407,6 +408,27 @@ async def extractExactCkTimes(
     except Exception as e:
         body = ErrorModel(error=str(e))
         return ResponseModel(statusCode=500, body=body)
+
+@app.get("/searchForKernelsets")
+async def searchForKernelsets(
+    spiceqlNames: Annotated[list[str], Query()] | str = [],
+    types: Annotated[list[str], Query()] | str = [],
+    startTime: float = -sys.float_info.max,
+    stopTime: float = sys.float_info.max,
+    ckQualities: Annotated[list[str], Query()] | str | None = ["smithed", "reconstructed"],
+    spkQualities: Annotated[list[str], Query()] | str | None = ["smithed", "reconstructed"]):
+    try:
+        spiceqlNames = strToList(spiceqlNames)
+        types = strToList(types)
+        ckQualities = strToList(ckQualities)
+        spkQualities = strToList(spkQualities)
+        kernels = pyspiceql.search_for_kernelsets(spiceqlNames, types, startTime, stopTime, ckQualities, spkQualities, False)
+        body = ResultModel(result={}, kernels=kernels)
+        return ResponseModel(statusCode=200, body=body)
+    except Exception as e:
+        body = ErrorModel(error=str(e))
+        return ResponseModel(statusCode=500, body=body)
+
 
 def calculate_ets(startEts, stopEts, exposureDuration) -> list:
     ets = []


### PR DESCRIPTION
Adds REST endpoint `/searchForKernelsets` that exposes the `search_for_kernelsets()` function in InventoryImpl.cpp.

Local example request: http://127.0.0.1:8080/searchForKernelsets?spiceqlNames=[base,mro]&types=[lsk,spk,pck]

Response:
```json
{"statusCode":200,"body":{"return":{},"kernels":{"lsk":["base/kernels/lsk/naif0012.tls"],"mro_spk_quality":"reconstructed","pck":["base/kernels/pck/pck00009.tpc","mro/kernels/pck/pck00008.tpc"],"spk":["mro/kernels/spk/mro_cruise.bsp"]}}}
```
## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

