### PR TITLE
1.2.0 Release Prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ release.
 
 ## [Unreleased]
 
+## 1.2.0
+
 ### Added
 - Added file creation permission verification before creating database and resolve database creation to specified mission list only if `mlist` is set [#75](https://github.com/DOI-USGS/SpiceQL/pull/75)
 - Added /searchForKernelsets REST endpoint [#76](https://github.com/DOI-USGS/SpiceQL/pull/76)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(CMakeDependentOption)
 cmake_minimum_required(VERSION 3.10)
-project(SpiceQL VERSION 1.1.3 DESCRIPTION "Spice Query Library")
+project(SpiceQL VERSION 1.2.0 DESCRIPTION "Spice Query Library")
 set(PACKAGE_VERSION ${PROJECT_VERSION})
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")


### PR DESCRIPTION
Update docs for 1.2.0, changes include:

### Added
- Added file creation permission verification before creating database and resolve database creation to specified mission list only if `mlist` is set [#75](https://github.com/DOI-USGS/SpiceQL/pull/75)
- Added /searchForKernelsets REST endpoint [#76](https://github.com/DOI-USGS/SpiceQL/pull/76)

### Fixed
- Fixed default SpiceQL REST URL [#63](https://github.com/DOI-USGS/SpiceQL/pull/63)
- Added missing db files (dawn, mariner10, near, and rosetta) to CMakeLists.txt [#69](https://github.com/DOI-USGS/SpiceQL/pull/69)
- Fixed ordering of `tspks` when dependencies are merged within the database structures [#65](https://github.com/DOI-USGS/SpiceQL/pull/65)
- Added `limitQuality` option and removed `enforceQuality` option [#74](https://github.com/DOI-USGS/SpiceQL/pull/74)

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

