### PR TITLE
Turn limitQuality into limitCk and limitSpk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+- Fixed default `limitQuality` option to `false` [#80](https://github.com/DOI-USGS/SpiceQL/pull/80)
+
 ## 1.2.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,8 @@ release.
 
 ## [Unreleased]
 
-### Fixed
-- Fixed default `limitQuality` option to `false` [#80](https://github.com/DOI-USGS/SpiceQL/pull/80)
+### Changed
+- Turned `limitQuality` into `limitCk` and `limitSpk` query params [#80](https://github.com/DOI-USGS/SpiceQL/pull/80)
 
 ## 1.2.0
 

--- a/SpiceQL/include/api.h
+++ b/SpiceQL/include/api.h
@@ -46,7 +46,7 @@ namespace SpiceQL {
      *
      * @return A vector of vectors with a Nx7 state vector of positions and velocities in x,y,z,vx,vy,vz format followed by the light time adjustment.
      **/
-    std::pair<std::vector<std::vector<double>>, nlohmann::json> getTargetStates(std::vector<double> ets, std::string target, std::string observer, std::string frame, std::string abcorr, std::string mission, std::vector<std::string> ckQualities={"smithed", "reconstructed"}, std::vector<std::string> spkQualities={"smithed", "reconstructed"}, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, bool limitQuality=true, std::vector<std::string> kernelList={});
+    std::pair<std::vector<std::vector<double>>, nlohmann::json> getTargetStates(std::vector<double> ets, std::string target, std::string observer, std::string frame, std::string abcorr, std::string mission, std::vector<std::string> ckQualities={"smithed", "reconstructed"}, std::vector<std::string> spkQualities={"smithed", "reconstructed"}, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, bool limitQuality=false, std::vector<std::string> kernelList={});
     
     /**
      * @brief Gives quaternion and angular velocity for a given frame at a set of ephemeris times
@@ -69,7 +69,7 @@ namespace SpiceQL {
      *
      * @returns Vector of SPICE-style quaternions (w,x,y,z) and optional angular velocity (4 element without angular velocity, 7 element with)
      **/
-    std::pair<std::vector<std::vector<double>>, nlohmann::json> getTargetOrientations(std::vector<double> ets, int toFrame, int refFrame, std::string mission, std::vector<std::string> ckQualities={"smithed", "reconstructed"}, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, bool limitQuality=true, std::vector<std::string> kernelList={});
+    std::pair<std::vector<std::vector<double>>, nlohmann::json> getTargetOrientations(std::vector<double> ets, int toFrame, int refFrame, std::string mission, std::vector<std::string> ckQualities={"smithed", "reconstructed"}, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, bool limitQuality=false, std::vector<std::string> kernelList={});
     
     /**
      * @brief Converts a given string spacecraft clock time to an ephemeris time
@@ -87,7 +87,7 @@ namespace SpiceQL {
      * @param kernelList vector<string> vector of additional kernels to load     
      * @return double
      */
-    std::pair<double, nlohmann::json> strSclkToEt(int frameCode, std::string sclk, std::string mission, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, bool limitQuality=true, std::vector<std::string> kernelList={});
+    std::pair<double, nlohmann::json> strSclkToEt(int frameCode, std::string sclk, std::string mission, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, bool limitQuality=false, std::vector<std::string> kernelList={});
 
     /**
      * @brief Converts a given double spacecraft clock time to an ephemeris time
@@ -105,7 +105,7 @@ namespace SpiceQL {
      * @param kernelList vector<string> vector of additional kernels to load 
      * @return double
      */
-    std::pair<double, nlohmann::json> doubleSclkToEt(int frameCode, double sclk, std::string mission, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, bool limitQuality=true, std::vector<std::string> kernelList={});
+    std::pair<double, nlohmann::json> doubleSclkToEt(int frameCode, double sclk, std::string mission, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, bool limitQuality=false, std::vector<std::string> kernelList={});
 
 
     /**
@@ -124,7 +124,7 @@ namespace SpiceQL {
      * @param kernelList vector<string> vector of additional kernels to load 
      * @return double
      */
-    std::pair<std::string, nlohmann::json> doubleEtToSclk(int frameCode, double et, std::string mission, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, bool limitQuality=true, std::vector<std::string> kernelList={});
+    std::pair<std::string, nlohmann::json> doubleEtToSclk(int frameCode, double et, std::string mission, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, bool limitQuality=false, std::vector<std::string> kernelList={});
 
 
     /**
@@ -139,7 +139,7 @@ namespace SpiceQL {
      * @param limitQuality bool only returns higher priority quality kernel if true
      * @returns double precision ephemeris time
      **/
-    std::pair<double, nlohmann::json> utcToEt(std::string utc, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, bool limitQuality=true, std::vector<std::string> kernelList={});
+    std::pair<double, nlohmann::json> utcToEt(std::string utc, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, bool limitQuality=false, std::vector<std::string> kernelList={});
 
     /**
      * @brief convert et string to a UTC string
@@ -156,7 +156,7 @@ namespace SpiceQL {
      *
      * @returns double precision ephemeris time
      **/
-    std::pair<std::string, nlohmann::json> etToUtc(double et, std::string format, double precision, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, bool limitQuality=true, std::vector<std::string> kernelList={});
+    std::pair<std::string, nlohmann::json> etToUtc(double et, std::string format, double precision, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, bool limitQuality=false, std::vector<std::string> kernelList={});
 
     /**
      * @brief Switch between NAIF frame string name to integer frame code
@@ -172,7 +172,7 @@ namespace SpiceQL {
      * 
      * @return integer Naif frame code
      **/
-    std::pair<int, nlohmann::json> translateNameToCode(std::string frame, std::string mission, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, bool limitQuality=true, std::vector<std::string> kernelList={});
+    std::pair<int, nlohmann::json> translateNameToCode(std::string frame, std::string mission, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, bool limitQuality=false, std::vector<std::string> kernelList={});
 
     /**
      * @brief Switch between NAIF frame integer code to string frame name
@@ -188,7 +188,7 @@ namespace SpiceQL {
      *
      * @return string Naif frame name
      **/
-    std::pair<std::string, nlohmann::json> translateCodeToName(int frame, std::string mission, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, bool limitQuality=true, std::vector<std::string> kernelList={});
+    std::pair<std::string, nlohmann::json> translateCodeToName(int frame, std::string mission, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, bool limitQuality=false, std::vector<std::string> kernelList={});
 
     /**
      * @brief Get the center, class id, and class of a given frame
@@ -204,7 +204,7 @@ namespace SpiceQL {
      *
      * @return 3 element vector of the given frames center, class id, and class
      **/
-    std::pair<std::vector<int>, nlohmann::json> getFrameInfo(int frame, std::string mission, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, bool limitQuality=true, std::vector<std::string> kernelList={});
+    std::pair<std::vector<int>, nlohmann::json> getFrameInfo(int frame, std::string mission, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, bool limitQuality=false, std::vector<std::string> kernelList={});
 
      /**
     * @brief returns frame name and frame code associated to the target ID.
@@ -220,7 +220,7 @@ namespace SpiceQL {
     * 
     * @returns json of frame name and frame code
     **/
-    std::pair<nlohmann::json, nlohmann::json> getTargetFrameInfo(int targetId, std::string mission, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, bool limitQuality=true, std::vector<std::string> kernelList={});
+    std::pair<nlohmann::json, nlohmann::json> getTargetFrameInfo(int targetId, std::string mission, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, bool limitQuality=false, std::vector<std::string> kernelList={});
 
     /**
     * @brief returns kernel values for a specific mission in the form of a json
@@ -234,7 +234,7 @@ namespace SpiceQL {
     * @param searchKernels bool Whether to search the kernels for the user
     * @returns json of values
     **/
-    std::pair<nlohmann::json, nlohmann::json> findMissionKeywords(std::string key, std::string mission, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, bool limitQuality=true, std::vector<std::string> kernelList={});
+    std::pair<nlohmann::json, nlohmann::json> findMissionKeywords(std::string key, std::string mission, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, bool limitQuality=false, std::vector<std::string> kernelList={});
 
     /**
     * @brief returns Target values in the form of a vector
@@ -251,7 +251,7 @@ namespace SpiceQL {
     *
     * @returns vector of values
     **/
-    std::pair<nlohmann::json, nlohmann::json> findTargetKeywords(std::string key, std::string mission, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, bool limitQuality=true, std::vector<std::string> kernelList={});
+    std::pair<nlohmann::json, nlohmann::json> findTargetKeywords(std::string key, std::string mission, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, bool limitQuality=false, std::vector<std::string> kernelList={});
 
     /**
      * @brief Given an ephemeris time and a starting frame, find the path from that starting frame to J2000 (1)
@@ -272,7 +272,7 @@ namespace SpiceQL {
      * @returns A two element vector of vectors ints, where the first element is the sequence of time dependent frames
      * and the second is the sequence of constant frames
      **/
-    std::pair<std::vector<std::vector<int>>, nlohmann::json> frameTrace(double et, int initialFrame, std::string mission, std::vector<std::string> ckQualities={"smithed", "reconstructed"}, std::vector<std::string> spkQualities={"smithed", "reconstructed"}, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, bool limitQuality=true, std::vector<std::string> kernelList={});
+    std::pair<std::vector<std::vector<int>>, nlohmann::json> frameTrace(double et, int initialFrame, std::string mission, std::vector<std::string> ckQualities={"smithed", "reconstructed"}, std::vector<std::string> spkQualities={"smithed", "reconstructed"}, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, bool limitQuality=false, std::vector<std::string> kernelList={});
 
     /**
      * @brief Extracts all segment times between observStart and observeEnd
@@ -291,7 +291,7 @@ namespace SpiceQL {
      *
      * @returns A list of times
      **/
-    std::pair<std::vector<double>, nlohmann::json> extractExactCkTimes(double observStart, double observEnd, int targetFrame, std::string mission, std::vector<std::string> ckQualities={"smithed", "reconstructed"}, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, bool limitQuality=true, std::vector<std::string> kernelList={});
+    std::pair<std::vector<double>, nlohmann::json> extractExactCkTimes(double observStart, double observEnd, int targetFrame, std::string mission, std::vector<std::string> ckQualities={"smithed", "reconstructed"}, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, bool limitQuality=false, std::vector<std::string> kernelList={});
 
     /**
      * @brief Searches for kernels given mission(s) and parameters.

--- a/SpiceQL/include/api.h
+++ b/SpiceQL/include/api.h
@@ -38,7 +38,8 @@ namespace SpiceQL {
      * @param spkQualities string of strings describing the quality of spks to try and obtain
      * @param searchKernels bool Whether to search the kernels for the user
      * @param fullKernelPath bool if true returns full kernel paths, default returns relative paths
-     * @param limitQuality bool only returns higher priority quality kernel if true
+     * @param limitCk int number of cks to limit to, default is -1 to retrieve all
+     * @param limitSpk int number of spks to limit to, default is 1 to retrieve only one
      * @param kernelList vector<string> vector of additional kernels to load 
      * 
      * @see SpiceQL::getTargetState
@@ -46,7 +47,7 @@ namespace SpiceQL {
      *
      * @return A vector of vectors with a Nx7 state vector of positions and velocities in x,y,z,vx,vy,vz format followed by the light time adjustment.
      **/
-    std::pair<std::vector<std::vector<double>>, nlohmann::json> getTargetStates(std::vector<double> ets, std::string target, std::string observer, std::string frame, std::string abcorr, std::string mission, std::vector<std::string> ckQualities={"smithed", "reconstructed"}, std::vector<std::string> spkQualities={"smithed", "reconstructed"}, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, bool limitQuality=false, std::vector<std::string> kernelList={});
+    std::pair<std::vector<std::vector<double>>, nlohmann::json> getTargetStates(std::vector<double> ets, std::string target, std::string observer, std::string frame, std::string abcorr, std::string mission, std::vector<std::string> ckQualities={"smithed", "reconstructed"}, std::vector<std::string> spkQualities={"smithed", "reconstructed"}, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, int limitCk=-1, int limitSpk=1, std::vector<std::string> kernelList={});
     
     /**
      * @brief Gives quaternion and angular velocity for a given frame at a set of ephemeris times
@@ -62,14 +63,15 @@ namespace SpiceQL {
      * @param ckQualities vector of string describing the quality of cks to try and obtain
      * @param searchKernels bool Whether to search the kernels for the user
      * @param fullKernelPath bool if true returns full kernel paths, default returns relative paths
-     * @param limitQuality bool only returns higher priority quality kernel if true
+     * @param limitCk int number of cks to limit to, default is -1 to retrieve all
+     * @param limitSpk int number of spks to limit to, default is 1 to retrieve only one
      * @param kernelList vector<string> vector of additional kernels to load 
      *
      * @see SpiceQL::getTargetOrientation
      *
      * @returns Vector of SPICE-style quaternions (w,x,y,z) and optional angular velocity (4 element without angular velocity, 7 element with)
      **/
-    std::pair<std::vector<std::vector<double>>, nlohmann::json> getTargetOrientations(std::vector<double> ets, int toFrame, int refFrame, std::string mission, std::vector<std::string> ckQualities={"smithed", "reconstructed"}, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, bool limitQuality=false, std::vector<std::string> kernelList={});
+    std::pair<std::vector<std::vector<double>>, nlohmann::json> getTargetOrientations(std::vector<double> ets, int toFrame, int refFrame, std::string mission, std::vector<std::string> ckQualities={"smithed", "reconstructed"}, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, int limitCk=-1, int limitSpk=1, std::vector<std::string> kernelList={});
     
     /**
      * @brief Converts a given string spacecraft clock time to an ephemeris time
@@ -83,11 +85,12 @@ namespace SpiceQL {
      * @param mission string Mission name as it relates to the config files
      * @param searchKernels bool Whether to search the kernels for the user
      * @param fullKernelPath bool if true returns full kernel paths, default returns relative paths
-     * @param limitQuality bool only returns higher priority quality kernel if true
+     * @param limitCk int number of cks to limit to, default is -1 to retrieve all
+     * @param limitSpk int number of spks to limit to, default is 1 to retrieve only one
      * @param kernelList vector<string> vector of additional kernels to load     
      * @return double
      */
-    std::pair<double, nlohmann::json> strSclkToEt(int frameCode, std::string sclk, std::string mission, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, bool limitQuality=false, std::vector<std::string> kernelList={});
+    std::pair<double, nlohmann::json> strSclkToEt(int frameCode, std::string sclk, std::string mission, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, int limitCk=-1, int limitSpk=1, std::vector<std::string> kernelList={});
 
     /**
      * @brief Converts a given double spacecraft clock time to an ephemeris time
@@ -101,11 +104,12 @@ namespace SpiceQL {
      * @param mission string Mission name as it relates to the config files
      * @param searchKernels bool Whether to search the kernels for the user
      * @param fullKernelPath bool if true returns full kernel paths, default returns relative paths
-     * @param limitQuality bool only returns higher priority quality kernel if true
+     * @param limitCk int number of cks to limit to, default is -1 to retrieve all
+     * @param limitSpk int number of spks to limit to, default is 1 to retrieve only one
      * @param kernelList vector<string> vector of additional kernels to load 
      * @return double
      */
-    std::pair<double, nlohmann::json> doubleSclkToEt(int frameCode, double sclk, std::string mission, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, bool limitQuality=false, std::vector<std::string> kernelList={});
+    std::pair<double, nlohmann::json> doubleSclkToEt(int frameCode, double sclk, std::string mission, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, int limitCk=-1, int limitSpk=1, std::vector<std::string> kernelList={});
 
 
     /**
@@ -120,11 +124,12 @@ namespace SpiceQL {
      * @param mission string Mission name as it relates to the config files
      * @param searchKernels bool Whether to search the kernels for the user
      * @param fullKernelPath bool if true returns full kernel paths, default returns relative paths
-     * @param limitQuality bool only returns higher priority quality kernel if true
+     * @param limitCk int number of cks to limit to, default is -1 to retrieve all
+     * @param limitSpk int number of spks to limit to, default is 1 to retrieve only one
      * @param kernelList vector<string> vector of additional kernels to load 
      * @return double
      */
-    std::pair<std::string, nlohmann::json> doubleEtToSclk(int frameCode, double et, std::string mission, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, bool limitQuality=false, std::vector<std::string> kernelList={});
+    std::pair<std::string, nlohmann::json> doubleEtToSclk(int frameCode, double et, std::string mission, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, int limitCk=-1, int limitSpk=1, std::vector<std::string> kernelList={});
 
 
     /**
@@ -136,10 +141,11 @@ namespace SpiceQL {
      * @param et UTC string, e.g. "1988 June 13, 12:29:48 TDB"
      * @param searchKernels bool Whether to search the kernels for the user
      * @param fullKernelPath bool if true returns full kernel paths, default returns relative paths
-     * @param limitQuality bool only returns higher priority quality kernel if true
+     * @param limitCk int number of cks to limit to, default is -1 to retrieve all
+     * @param limitSpk int number of spks to limit to, default is 1 to retrieve only one
      * @returns double precision ephemeris time
      **/
-    std::pair<double, nlohmann::json> utcToEt(std::string utc, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, bool limitQuality=false, std::vector<std::string> kernelList={});
+    std::pair<double, nlohmann::json> utcToEt(std::string utc, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, int limitCk=-1, int limitSpk=1, std::vector<std::string> kernelList={});
 
     /**
      * @brief convert et string to a UTC string
@@ -151,12 +157,13 @@ namespace SpiceQL {
      * @param precision number of decimal 
      * @param searchKernels bool Whether to search the kernels for the user
      * @param fullKernelPath bool if true returns full kernel paths, default returns relative paths
-     * @param limitQuality bool only returns higher priority quality kernel if true
+     * @param limitCk int number of cks to limit to, default is -1 to retrieve all
+     * @param limitSpk int number of spks to limit to, default is 1 to retrieve only one
      * @param kernelList vector<string> vector of additional kernels to load 
      *
      * @returns double precision ephemeris time
      **/
-    std::pair<std::string, nlohmann::json> etToUtc(double et, std::string format, double precision, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, bool limitQuality=false, std::vector<std::string> kernelList={});
+    std::pair<std::string, nlohmann::json> etToUtc(double et, std::string format, double precision, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, int limitCk=-1, int limitSpk=1, std::vector<std::string> kernelList={});
 
     /**
      * @brief Switch between NAIF frame string name to integer frame code
@@ -167,12 +174,13 @@ namespace SpiceQL {
      * @param mission Mission name as it relates to the config files
      * @param searchKernels bool Whether to search the kernels for the user
      * @param fullKernelPath bool if true returns full kernel paths, default returns relative paths
-     * @param limitQuality bool only returns higher priority quality kernel if true
+     * @param limitCk int number of cks to limit to, default is -1 to retrieve all
+     * @param limitSpk int number of spks to limit to, default is 1 to retrieve only one
      * @param kernelList vector<string> vector of additional kernels to load 
      * 
      * @return integer Naif frame code
      **/
-    std::pair<int, nlohmann::json> translateNameToCode(std::string frame, std::string mission, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, bool limitQuality=false, std::vector<std::string> kernelList={});
+    std::pair<int, nlohmann::json> translateNameToCode(std::string frame, std::string mission, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, int limitCk=-1, int limitSpk=1, std::vector<std::string> kernelList={});
 
     /**
      * @brief Switch between NAIF frame integer code to string frame name
@@ -183,12 +191,13 @@ namespace SpiceQL {
      * @param searchKernels bool Whether to search the kernels for the user
      * @param mission Mission name as it relates to the config files
      * @param fullKernelPath bool if true returns full kernel paths, default returns relative paths
-     * @param limitQuality bool only returns higher priority quality kernel if true
+     * @param limitCk int number of cks to limit to, default is -1 to retrieve all
+     * @param limitSpk int number of spks to limit to, default is 1 to retrieve only one
      * @param kernelList vector<string> vector of additional kernels to load 
      *
      * @return string Naif frame name
      **/
-    std::pair<std::string, nlohmann::json> translateCodeToName(int frame, std::string mission, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, bool limitQuality=false, std::vector<std::string> kernelList={});
+    std::pair<std::string, nlohmann::json> translateCodeToName(int frame, std::string mission, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, int limitCk=-1, int limitSpk=1, std::vector<std::string> kernelList={});
 
     /**
      * @brief Get the center, class id, and class of a given frame
@@ -199,12 +208,13 @@ namespace SpiceQL {
      * @param mission Mission name as it relates to the config files
      * @param searchKernels bool Whether to search the kernels for the user
      * @param fullKernelPath bool if true returns full kernel paths, default returns relative paths
-    * @param limitQuality bool only returns higher priority quality kernel if true
+     * @param limitCk int number of cks to limit to, default is -1 to retrieve all
+     * @param limitSpk int number of spks to limit to, default is 1 to retrieve only one
      * @param kernelList vector<string> vector of additional kernels to load 
      *
      * @return 3 element vector of the given frames center, class id, and class
      **/
-    std::pair<std::vector<int>, nlohmann::json> getFrameInfo(int frame, std::string mission, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, bool limitQuality=false, std::vector<std::string> kernelList={});
+    std::pair<std::vector<int>, nlohmann::json> getFrameInfo(int frame, std::string mission, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, int limitCk=-1, int limitSpk=1, std::vector<std::string> kernelList={});
 
      /**
     * @brief returns frame name and frame code associated to the target ID.
@@ -215,12 +225,13 @@ namespace SpiceQL {
     * @param mission mission name as it relates to the config files
     * @param searchKernels bool Whether to search the kernels for the user
     * @param fullKernelPath bool if true returns full kernel paths, default returns relative paths
-    * @param limitQuality bool only returns higher priority quality kernel if true
+    * @param limitCk int number of cks to limit to, default is -1 to retrieve all
+    * @param limitSpk int number of spks to limit to, default is 1 to retrieve only one
     * @param kernelList vector<string> vector of additional kernels to load 
     * 
     * @returns json of frame name and frame code
     **/
-    std::pair<nlohmann::json, nlohmann::json> getTargetFrameInfo(int targetId, std::string mission, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, bool limitQuality=false, std::vector<std::string> kernelList={});
+    std::pair<nlohmann::json, nlohmann::json> getTargetFrameInfo(int targetId, std::string mission, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, int limitCk=-1, int limitSpk=1, std::vector<std::string> kernelList={});
 
     /**
     * @brief returns kernel values for a specific mission in the form of a json
@@ -230,11 +241,12 @@ namespace SpiceQL {
     * @param key key - Kernel to get values from 
     * @param mission mission name
     * @param fullKernelPath bool if true returns full kernel paths, default returns relative paths
-    * @param limitQuality bool only returns higher priority quality kernel if true
+    * @param limitCk int number of cks to limit to, default is -1 to retrieve all
+    * @param limitSpk int number of spks to limit to, default is 1 to retrieve only one
     * @param searchKernels bool Whether to search the kernels for the user
     * @returns json of values
     **/
-    std::pair<nlohmann::json, nlohmann::json> findMissionKeywords(std::string key, std::string mission, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, bool limitQuality=false, std::vector<std::string> kernelList={});
+    std::pair<nlohmann::json, nlohmann::json> findMissionKeywords(std::string key, std::string mission, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, int limitCk=-1, int limitSpk=1, std::vector<std::string> kernelList={});
 
     /**
     * @brief returns Target values in the form of a vector
@@ -246,12 +258,13 @@ namespace SpiceQL {
     * @param mission mission name as it relates to the config files
     * @param searchKernels bool Whether to search the kernels for the user
     * @param fullKernelPath bool if true returns full kernel paths, default returns relative paths
-    * @param limitQuality bool only returns higher priority quality kernel if true
+    * @param limitCk int number of cks to limit to, default is -1 to retrieve all
+    * @param limitSpk int number of spks to limit to, default is 1 to retrieve only one
     * @param kernelList vector<string> vector of additional kernels to load 
     *
     * @returns vector of values
     **/
-    std::pair<nlohmann::json, nlohmann::json> findTargetKeywords(std::string key, std::string mission, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, bool limitQuality=false, std::vector<std::string> kernelList={});
+    std::pair<nlohmann::json, nlohmann::json> findTargetKeywords(std::string key, std::string mission, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, int limitCk=-1, int limitSpk=1, std::vector<std::string> kernelList={});
 
     /**
      * @brief Given an ephemeris time and a starting frame, find the path from that starting frame to J2000 (1)
@@ -266,13 +279,14 @@ namespace SpiceQL {
      * @param spkQualities vector of strings describing the quality of spks to try and obtain
      * @param searchKernels bool Whether to search the kernels for the user
      * @param fullKernelPath bool if true returns full kernel paths, default returns relative paths
-     * @param limitQuality bool only returns higher priority quality kernel if true
+     * @param limitCk int number of cks to limit to, default is -1 to retrieve all
+     * @param limitSpk int number of spks to limit to, default is 1 to retrieve only one
      * @param kernelList vector<string> vector of additional kernels to load 
      *
      * @returns A two element vector of vectors ints, where the first element is the sequence of time dependent frames
      * and the second is the sequence of constant frames
      **/
-    std::pair<std::vector<std::vector<int>>, nlohmann::json> frameTrace(double et, int initialFrame, std::string mission, std::vector<std::string> ckQualities={"smithed", "reconstructed"}, std::vector<std::string> spkQualities={"smithed", "reconstructed"}, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, bool limitQuality=false, std::vector<std::string> kernelList={});
+    std::pair<std::vector<std::vector<int>>, nlohmann::json> frameTrace(double et, int initialFrame, std::string mission, std::vector<std::string> ckQualities={"smithed", "reconstructed"}, std::vector<std::string> spkQualities={"smithed", "reconstructed"}, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, int limitCk=-1, int limitSpk=1, std::vector<std::string> kernelList={});
 
     /**
      * @brief Extracts all segment times between observStart and observeEnd
@@ -286,12 +300,13 @@ namespace SpiceQL {
      * @param targetFrame Target reference frame to get ephemeris data in
      * @param ckQualities vector of string describing the quality of cks to try and obtain
      * @param fullKernelPath bool if true returns full kernel paths, default returns relative paths
-     * @param limitQuality bool only returns higher priority quality kernel if true
+     * @param limitCk int number of cks to limit to, default is -1 to retrieve all
+     * @param limitSpk int number of spks to limit to, default is 1 to retrieve only one
      * @param kernelList vector<string> vector of additional kernels to load 
      *
      * @returns A list of times
      **/
-    std::pair<std::vector<double>, nlohmann::json> extractExactCkTimes(double observStart, double observEnd, int targetFrame, std::string mission, std::vector<std::string> ckQualities={"smithed", "reconstructed"}, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, bool limitQuality=false, std::vector<std::string> kernelList={});
+    std::pair<std::vector<double>, nlohmann::json> extractExactCkTimes(double observStart, double observEnd, int targetFrame, std::string mission, std::vector<std::string> ckQualities={"smithed", "reconstructed"}, bool useWeb=false, bool searchKernels=true, bool fullKernelPath=false, int limitCk=-1, int limitSpk=1, std::vector<std::string> kernelList={});
 
     /**
      * @brief Searches for kernels given mission(s) and parameters.
@@ -306,11 +321,13 @@ namespace SpiceQL {
      * @param spkQualities vector of string describing the quality of spks to try and obtain
      * @param useWeb whether to use web SpiceQL
      * @param fullKernelPath bool if true returns full kernel paths, default returns relative paths
+     * @param limitCk limitCk int number of cks to limit to, default is -1 to retrieve all
+     * @param limitSpk int number of spks to limit to, default is 1 to retrieve only one
      * @param overwrite subkernels will take precedent over parent mission kernels if true
      *
      * @returns An empty return and list of kernels
      **/
     std::pair<std::string, nlohmann::json> searchForKernelsets(std::vector<std::string> spiceqlNames, std::vector<std::string> types={"ck", "spk", "tspk", "lsk", "mk", "sclk", "iak", "ik", "fk", "dsk", "pck", "ek"}, 
         double startTime=-std::numeric_limits<double>::max(), double stopTime=std::numeric_limits<double>::max(), std::vector<std::string> ckQualities={"smithed", "reconstructed"}, std::vector<std::string> spkQualities={"smithed", "reconstructed"}, 
-        bool useWeb=false, bool fullKernelPath=false, bool overwrite=false);
+        bool useWeb=false, bool fullKernelPath=false, int limitCk=-1, int limitSpk=1, bool overwrite=false);
 }

--- a/SpiceQL/include/inventory.h
+++ b/SpiceQL/include/inventory.h
@@ -18,9 +18,9 @@
 namespace SpiceQL {
     namespace Inventory { 
         nlohmann::json search_for_kernelset(std::string spiceql_name, std::vector<std::string> types=KERNEL_TYPES, double start_time=-std::numeric_limits<double>::max(), double stop_time=std::numeric_limits<double>::max(), 
-                                      std::vector<std::string> ckQualities={"smithed", "reconstructed"}, std::vector<std::string> spkQualities={"smithed", "reconstructed"}, bool full_kernel_path=false, bool limit_quality=true);
+                                      std::vector<std::string> ckQualities={"smithed", "reconstructed"}, std::vector<std::string> spkQualities={"smithed", "reconstructed"}, bool full_kernel_path=false, int limit_ck=-1, int limit_spk=1);
         nlohmann::json search_for_kernelsets(std::vector<std::string> spiceql_names, std::vector<std::string> types=KERNEL_TYPES, double start_time=-std::numeric_limits<double>::max(), double stop_time=std::numeric_limits<double>::max(), 
-                                      std::vector<std::string> ckQualities={"smithed", "reconstructed"}, std::vector<std::string> spkQualities={"smithed", "reconstructed"}, bool full_kernel_path=false, bool limit_quality=true,
+                                      std::vector<std::string> ckQualities={"smithed", "reconstructed"}, std::vector<std::string> spkQualities={"smithed", "reconstructed"}, bool full_kernel_path=false, int limit_ck=-1, int limit_spk=1,
                                       bool overwrite=false);    
         nlohmann::json search_for_kernelset_from_regex(std::vector<std::string> list, bool full_kernel_path=false);
 

--- a/SpiceQL/include/inventoryimpl.h
+++ b/SpiceQL/include/inventoryimpl.h
@@ -43,10 +43,10 @@ namespace SpiceQL {
     void write_database();
     nlohmann::json search_for_kernelset(std::string spiceql_name, std::vector<Kernel::Type> types, double start_time=-std::numeric_limits<double>::max(), double stop_time=std::numeric_limits<double>::max(),
                                             std::vector<Kernel::Quality> ckQualities={Kernel::Quality::SMITHED, Kernel::Quality::RECONSTRUCTED}, std::vector<Kernel::Quality> spkQualities={Kernel::Quality::SMITHED, Kernel::Quality::RECONSTRUCTED},
-                                            bool full_kernel_path=false, bool limit_quality=true);
+                                            bool full_kernel_path=false, int limit_ck=-1, int limit_spk=1);
     nlohmann::json search_for_kernelsets(std::vector<std::string> spiceql_names, std::vector<Kernel::Type> types, double start_time=-std::numeric_limits<double>::max(), double stop_time=std::numeric_limits<double>::max(),
                                             std::vector<Kernel::Quality> ckQualities={Kernel::Quality::SMITHED, Kernel::Quality::RECONSTRUCTED}, std::vector<Kernel::Quality> spkQualities={Kernel::Quality::SMITHED, Kernel::Quality::RECONSTRUCTED},
-                                            bool full_kernel_path=false, bool limit_quality=true, bool overwrite=false);
+                                            bool full_kernel_path=false, int limit_ck=-1, int limit_spk=1, bool overwrite=false);
     nlohmann::json m_json_inventory; 
 
     std::map<std::string, std::vector<std::string>> m_nontimedep_kerns;  

--- a/SpiceQL/src/api.cpp
+++ b/SpiceQL/src/api.cpp
@@ -222,7 +222,7 @@ namespace SpiceQL {
 
     pair<vector<vector<double>>, json> getTargetStates(vector<double> ets, string target, string observer, string frame, string abcorr, string mission, 
                                                        vector<string> ckQualities, vector<string> spkQualities, bool useWeb, bool searchKernels, bool fullKernelPath, 
-                                                       bool limitQuality, vector<string> kernelList) {
+                                                       int limitCk, int limitSpk, vector<string> kernelList) {
         SPDLOG_TRACE("Calling getTargetStates with {}, {}, {}, {}, {}, {}, {}, {}, {}, {}", ets.size(), target, observer, frame, abcorr, mission, ckQualities.size(), spkQualities.size(), useWeb, searchKernels, kernelList.size());
 
         if (useWeb) {
@@ -238,7 +238,8 @@ namespace SpiceQL {
                 {"spkQualities", spkQualities},
                 {"searchKernels", searchKernels},
                 {"fullKernelPath", fullKernelPath},
-                {"limitQuality", limitQuality},
+                {"limitCk", limitCk},
+                {"limitSpk", limitSpk},
                 {"kernelList", kernelList}
                 });
             // @TODO check that json exists / contains what we're looking for
@@ -254,7 +255,7 @@ namespace SpiceQL {
         json ephemKernels = {};
 
         if (searchKernels) {
-            ephemKernels = Inventory::search_for_kernelsets({mission, target, observer, "base"}, {"sclk", "ck", "spk", "pck", "tspk", "lsk", "fk", "ik"}, ets.front(), ets.back(), ckQualities, spkQualities, fullKernelPath, limitQuality);
+            ephemKernels = Inventory::search_for_kernelsets({mission, target, observer, "base"}, {"sclk", "ck", "spk", "pck", "tspk", "lsk", "fk", "ik"}, ets.front(), ets.back(), ckQualities, spkQualities, fullKernelPath, limitCk, limitSpk);
             SPDLOG_DEBUG("{} Kernels : {}", mission, ephemKernels.dump(4));
         }
 
@@ -289,7 +290,7 @@ namespace SpiceQL {
 
     pair<vector<vector<double>>, json> getTargetOrientations(vector<double> ets, int toFrame, int refFrame, string mission, 
                                                              vector<string> ckQualities, bool useWeb, bool searchKernels, bool fullKernelPath, 
-                                                             bool limitQuality, vector<string> kernelList) {
+                                                             int limitCk, int limitSpk, vector<string> kernelList) {
         SPDLOG_TRACE("Calling getTargetOrientations with {}, {}, {}, {}, {}, {}, {}, {}", ets.size(), toFrame, refFrame, mission, ckQualities.size(), useWeb, searchKernels, kernelList.size());
 
         if (useWeb){
@@ -301,7 +302,8 @@ namespace SpiceQL {
                 {"ckQualities", ckQualities},
                 {"searchKernels", searchKernels},
                 {"fullKernelPath", fullKernelPath},
-                {"limitQuality", limitQuality},
+                {"limitCk", limitCk},
+                {"limitSpk", limitSpk},
                 {"kernelList", kernelList}
             });
             json out = spiceAPIQuery("getTargetOrientations", args);
@@ -316,7 +318,7 @@ namespace SpiceQL {
         json ephemKernels = {};
 
         if (searchKernels) {
-            ephemKernels = Inventory::search_for_kernelsets({mission, "base"}, {"sclk", "ck", "pck", "fk", "ik", "lsk", "tspk"}, ets.front(), ets.back(), ckQualities, {"noquality"}, fullKernelPath, limitQuality);
+            ephemKernels = Inventory::search_for_kernelsets({mission, "base"}, {"sclk", "ck", "pck", "fk", "ik", "lsk", "tspk"}, ets.front(), ets.back(), ckQualities, {"noquality"}, fullKernelPath, limitCk, limitSpk);
         }
 
         if (!kernelList.empty()) {
@@ -346,7 +348,7 @@ namespace SpiceQL {
     }
 
 
-    pair<double, json> strSclkToEt(int frameCode, string sclk, string mission, bool useWeb, bool searchKernels, bool fullKernelPath, bool limitQuality, vector<string> kernelList) {
+    pair<double, json> strSclkToEt(int frameCode, string sclk, string mission, bool useWeb, bool searchKernels, bool fullKernelPath, int limitCk, int limitSpk, vector<string> kernelList) {
         SPDLOG_TRACE("calling strSclkToEt({}, {}, {}, {}, {}, {})", frameCode, sclk, mission, useWeb, searchKernels, kernelList.size());
 
         if (useWeb) {
@@ -356,7 +358,8 @@ namespace SpiceQL {
                 {"mission", mission},
                 {"searchKernels", searchKernels},
                 {"fullKernelPath", fullKernelPath},
-                {"limitQuality", limitQuality},
+                {"limitCk", limitCk},
+                {"limitSpk", limitSpk},
                 {"kernelList", kernelList}
             });
             json out = spiceAPIQuery("strSclkToEt", args);
@@ -366,7 +369,7 @@ namespace SpiceQL {
 
         json ephemKernels;
         if (searchKernels) {
-            ephemKernels = Inventory::search_for_kernelsets({"base", mission}, {"lsk", "fk", "sclk"}, default_StartTime, default_StopTime, default_KernelQualities, default_KernelQualities, fullKernelPath, limitQuality); 
+            ephemKernels = Inventory::search_for_kernelsets({"base", mission}, {"lsk", "fk", "sclk"}, default_StartTime, default_StopTime, default_KernelQualities, default_KernelQualities, fullKernelPath, limitCk, limitSpk); 
         }
 
         if (!kernelList.empty()) {
@@ -395,7 +398,7 @@ namespace SpiceQL {
     }
 
 
-   pair<string, json> doubleEtToSclk(int frameCode, double et, string mission, bool useWeb, bool searchKernels, bool fullKernelPath, bool limitQuality, vector<string> kernelList) {
+   pair<string, json> doubleEtToSclk(int frameCode, double et, string mission, bool useWeb, bool searchKernels, bool fullKernelPath, int limitCk, int limitSpk, vector<string> kernelList) {
         SPDLOG_TRACE("calling doubleEtToSclk({}, {}, {}, {}, {}, {})", frameCode, et, mission, useWeb, searchKernels, kernelList.size());
 
         json ephemKernels;
@@ -407,7 +410,8 @@ namespace SpiceQL {
                 {"mission", mission},
                 {"searchKernels", searchKernels},
                 {"fullKernelPath", fullKernelPath},
-                {"limitQuality", limitQuality},
+                {"limitCk", limitCk},
+                {"limitSpk", limitSpk},
                 {"kernelList", kernelList}
             });
             json out = spiceAPIQuery("doubleEtToSclk", args);
@@ -416,7 +420,7 @@ namespace SpiceQL {
         }
 
         if (searchKernels) {
-          ephemKernels = Inventory::search_for_kernelsets({"base", mission}, {"fk", "lsk", "sclk"}, default_StartTime, default_StopTime, default_KernelQualities, default_KernelQualities, fullKernelPath, limitQuality); 
+          ephemKernels = Inventory::search_for_kernelsets({"base", mission}, {"fk", "lsk", "sclk"}, default_StartTime, default_StopTime, default_KernelQualities, default_KernelQualities, fullKernelPath, limitCk, limitSpk); 
         }
 
         if (!kernelList.empty()) {
@@ -437,7 +441,7 @@ namespace SpiceQL {
    }
 
 
-    pair<double, json> doubleSclkToEt(int frameCode, double sclk, string mission, bool useWeb, bool searchKernels, bool fullKernelPath, bool limitQuality, vector<string> kernelList) {
+    pair<double, json> doubleSclkToEt(int frameCode, double sclk, string mission, bool useWeb, bool searchKernels, bool fullKernelPath, int limitCk, int limitSpk, vector<string> kernelList) {
 
         if (useWeb){
             json args = json::object({
@@ -446,7 +450,8 @@ namespace SpiceQL {
                 {"mission", mission},
                 {"searchKernels", searchKernels},
                 {"fullKernelPath", fullKernelPath},
-                {"limitQuality", limitQuality},
+                {"limitCk", limitCk},
+                {"limitSpk", limitSpk},
                 {"kernelList", kernelList}
             });
             json out = spiceAPIQuery("doubleSclkToEt", args);
@@ -457,7 +462,7 @@ namespace SpiceQL {
         json sclks;
 
         if (searchKernels) {
-            sclks = Inventory::search_for_kernelsets({"base", mission}, {"lsk", "fk", "sclk"}, default_StartTime, default_StopTime, default_KernelQualities, default_KernelQualities, fullKernelPath, limitQuality);
+            sclks = Inventory::search_for_kernelsets({"base", mission}, {"lsk", "fk", "sclk"}, default_StartTime, default_StopTime, default_KernelQualities, default_KernelQualities, fullKernelPath, limitCk, limitSpk);
         }
 
         if (!kernelList.empty()) {
@@ -481,14 +486,15 @@ namespace SpiceQL {
     }
 
 
-    pair<double, json> utcToEt(string utc, bool useWeb, bool searchKernels, bool fullKernelPath, bool limitQuality, vector<string> kernelList) {
+    pair<double, json> utcToEt(string utc, bool useWeb, bool searchKernels, bool fullKernelPath, int limitCk, int limitSpk, vector<string> kernelList) {
         
         if (useWeb){
             json args = json::object({
                 {"utc", utc},
                 {"searchKernels", searchKernels},
                 {"fullKernelPath", fullKernelPath},
-                {"limitQuality", limitQuality},
+                {"limitCk", limitCk},
+                {"limitSpk", limitSpk},
                 {"kernelList", kernelList}
             });
             json out = spiceAPIQuery("utcToEt", args);
@@ -500,7 +506,7 @@ namespace SpiceQL {
 
         // get lsk kernel
         if (searchKernels) {
-            lsks = Inventory::search_for_kernelset("base", {"lsk"}, default_StartTime, default_StopTime, default_KernelQualities, default_KernelQualities, fullKernelPath, limitQuality);
+            lsks = Inventory::search_for_kernelset("base", {"lsk"}, default_StartTime, default_StopTime, default_KernelQualities, default_KernelQualities, fullKernelPath, limitCk, limitSpk);
         }
         if (!kernelList.empty()) {
             json regexk = Inventory::search_for_kernelset_from_regex(kernelList, fullKernelPath);
@@ -519,7 +525,7 @@ namespace SpiceQL {
     }
 
 
-    pair<string, json> etToUtc(double et, string format, double precision, bool useWeb, bool searchKernels, bool fullKernelPath, bool limitQuality, vector<string> kernelList) {
+    pair<string, json> etToUtc(double et, string format, double precision, bool useWeb, bool searchKernels, bool fullKernelPath, int limitCk, int limitSpk, vector<string> kernelList) {
     
         if (useWeb){
             json args = json::object({
@@ -528,7 +534,8 @@ namespace SpiceQL {
                 {"precision", precision},
                 {"searchKernels", searchKernels},
                 {"fullKernelPath", fullKernelPath},
-                {"limitQuality", limitQuality},
+                {"limitCk", limitCk},
+                {"limitSpk", limitSpk},
                 {"kernelList", kernelList}
             });
             json out = spiceAPIQuery("etToUtc", args);
@@ -540,7 +547,7 @@ namespace SpiceQL {
 
         // get lsk kernel
         if (searchKernels) {
-            lsks = Inventory::search_for_kernelset("base", {"lsk"}, default_StartTime, default_StopTime, default_KernelQualities, default_KernelQualities, fullKernelPath, limitQuality);
+            lsks = Inventory::search_for_kernelset("base", {"lsk"}, default_StartTime, default_StopTime, default_KernelQualities, default_KernelQualities, fullKernelPath, limitCk, limitSpk);
         }
         if (!kernelList.empty()) {
             json regexk = Inventory::search_for_kernelset_from_regex(kernelList, fullKernelPath);
@@ -559,7 +566,7 @@ namespace SpiceQL {
     }
 
 
-    pair<int, json> translateNameToCode(string frame, string mission, bool useWeb, bool searchKernels, bool fullKernelPath, bool limitQuality, vector<string> kernelList) {    
+    pair<int, json> translateNameToCode(string frame, string mission, bool useWeb, bool searchKernels, bool fullKernelPath, int limitCk, int limitSpk, vector<string> kernelList) {    
         
         if (useWeb){
             json args = json::object({
@@ -567,7 +574,8 @@ namespace SpiceQL {
                 {"mission", mission},
                 {"searchKernels", searchKernels},
                 {"fullKernelPath", fullKernelPath},
-                {"limitQuality", limitQuality},
+                {"limitCk", limitCk},
+                {"limitSpk", limitSpk},
                 {"kernelList", kernelList}
             });
             json out = spiceAPIQuery("translateNameToCode", args);
@@ -580,7 +588,7 @@ namespace SpiceQL {
         json kernelsToLoad = {};
 
         if (mission != "" && searchKernels) {
-            kernelsToLoad = Inventory::search_for_kernelset(mission, {"fk", "ik"}, default_StartTime, default_StopTime, default_KernelQualities, default_KernelQualities, fullKernelPath, limitQuality);
+            kernelsToLoad = Inventory::search_for_kernelset(mission, {"fk", "ik"}, default_StartTime, default_StopTime, default_KernelQualities, default_KernelQualities, fullKernelPath, limitCk, limitSpk);
         }
 
         if (!kernelList.empty()) {
@@ -608,7 +616,7 @@ namespace SpiceQL {
     }
 
 
-    pair<string, json> translateCodeToName(int frame, string mission, bool useWeb, bool searchKernels, bool fullKernelPath, bool limitQuality, vector<string> kernelList) {
+    pair<string, json> translateCodeToName(int frame, string mission, bool useWeb, bool searchKernels, bool fullKernelPath, int limitCk, int limitSpk, vector<string> kernelList) {
         
         if (useWeb){
             json args = json::object({
@@ -616,7 +624,8 @@ namespace SpiceQL {
                 {"mission", mission},
                 {"searchKernels", searchKernels},
                 {"fullKernelPath", fullKernelPath},
-                {"limitQuality", limitQuality},
+                {"limitCk", limitCk},
+                {"limitSpk", limitSpk},
                 {"kernelList", kernelList}
             });
             json out = spiceAPIQuery("translateCodeToName", args);
@@ -629,7 +638,7 @@ namespace SpiceQL {
         json kernelsToLoad = {};
 
         if (mission != "" && searchKernels){
-            kernelsToLoad = Inventory::search_for_kernelset(mission, {"fk"}, default_StartTime, default_StopTime, default_KernelQualities, default_KernelQualities, fullKernelPath, limitQuality);
+            kernelsToLoad = Inventory::search_for_kernelset(mission, {"fk"}, default_StartTime, default_StopTime, default_KernelQualities, default_KernelQualities, fullKernelPath, limitCk, limitSpk);
         }
         if (!kernelList.empty()) {
             json regexk = Inventory::search_for_kernelset_from_regex(kernelList, fullKernelPath);
@@ -656,7 +665,7 @@ namespace SpiceQL {
     }
 
 
-    pair<vector<int>, json> getFrameInfo(int frame, string mission, bool useWeb, bool searchKernels, bool fullKernelPath, bool limitQuality, vector<string> kernelList) {
+    pair<vector<int>, json> getFrameInfo(int frame, string mission, bool useWeb, bool searchKernels, bool fullKernelPath, int limitCk, int limitSpk, vector<string> kernelList) {
         
         if (useWeb){
             json args = json::object({
@@ -664,7 +673,8 @@ namespace SpiceQL {
                 {"mission", mission},
                 {"searchKernels", searchKernels},
                 {"fullKernelPath", fullKernelPath},
-                {"limitQuality", limitQuality},
+                {"limitCk", limitCk},
+                {"limitSpk", limitSpk},
                 {"kernelList", kernelList}
             });
             json out = spiceAPIQuery("getFrameInfo", args);
@@ -681,7 +691,7 @@ namespace SpiceQL {
 
         if (mission != "" && searchKernels) {
             // Load only the FKs
-            kernelsToLoad = Inventory::search_for_kernelset(mission, {"fk"}, default_StartTime, default_StopTime, default_KernelQualities, default_KernelQualities, fullKernelPath, limitQuality);
+            kernelsToLoad = Inventory::search_for_kernelset(mission, {"fk"}, default_StartTime, default_StopTime, default_KernelQualities, default_KernelQualities, fullKernelPath, limitCk, limitSpk);
         }
         if (!kernelList.empty()) {
             json regexk = Inventory::search_for_kernelset_from_regex(kernelList, fullKernelPath);
@@ -703,7 +713,7 @@ namespace SpiceQL {
     }
 
 
-    pair<json, json> getTargetFrameInfo(int targetId, string mission, bool useWeb, bool searchKernels, bool fullKernelPath, bool limitQuality, vector<string> kernelList) {
+    pair<json, json> getTargetFrameInfo(int targetId, string mission, bool useWeb, bool searchKernels, bool fullKernelPath, int limitCk, int limitSpk, vector<string> kernelList) {
         
         if (useWeb){
             json args = json::object({
@@ -711,7 +721,8 @@ namespace SpiceQL {
                 {"mission", mission},
                 {"searchKernels", searchKernels},
                 {"fullKernelPath", fullKernelPath},
-                {"limitQuality", limitQuality},
+                {"limitCk", limitCk},
+                {"limitSpk", limitSpk},
                 {"kernelList", kernelList}
             });
             json out = spiceAPIQuery("getTargetFrameInfo", args);
@@ -727,7 +738,7 @@ namespace SpiceQL {
         json kernelsToLoad = {};
 
         if (mission != "" && searchKernels) {
-            kernelsToLoad = Inventory::search_for_kernelsets({mission, "base"}, {"fk"}, default_StartTime, default_StopTime, default_KernelQualities, default_KernelQualities, fullKernelPath, limitQuality);
+            kernelsToLoad = Inventory::search_for_kernelsets({mission, "base"}, {"fk"}, default_StartTime, default_StopTime, default_KernelQualities, default_KernelQualities, fullKernelPath, limitCk, limitSpk);
         }
 
         if (!kernelList.empty()) {
@@ -753,7 +764,7 @@ namespace SpiceQL {
     }
 
 
-    pair<json, json> findMissionKeywords(string key, string mission, bool useWeb, bool searchKernels, bool fullKernelPath, bool limitQuality, vector<string> kernelList) {
+    pair<json, json> findMissionKeywords(string key, string mission, bool useWeb, bool searchKernels, bool fullKernelPath, int limitCk, int limitSpk, vector<string> kernelList) {
         
         if (useWeb){
             json args = json::object({
@@ -761,7 +772,8 @@ namespace SpiceQL {
                 {"mission", mission},
                 {"searchKernels", searchKernels},
                 {"fullKernelPath", fullKernelPath},
-                {"limitQuality", limitQuality},
+                {"limitCk", limitCk},
+                {"limitSpk", limitSpk},
                 {"kernelList", kernelList}
             });
             json out = spiceAPIQuery("findMissionKeywords", args);
@@ -772,7 +784,7 @@ namespace SpiceQL {
         json translationKernels = {};
 
         if (mission != "" && searchKernels) {
-            translationKernels = Inventory::search_for_kernelset(mission, {"iak", "fk", "ik"}, default_StartTime, default_StopTime, default_KernelQualities, default_KernelQualities, fullKernelPath, limitQuality);
+            translationKernels = Inventory::search_for_kernelset(mission, {"iak", "fk", "ik"}, default_StartTime, default_StopTime, default_KernelQualities, default_KernelQualities, fullKernelPath, limitCk, limitSpk);
         }
 
         if (!kernelList.empty()) {
@@ -787,7 +799,7 @@ namespace SpiceQL {
     }
 
 
-    pair<json, json> findTargetKeywords(string key, string mission, bool useWeb, bool searchKernels, bool fullKernelPath, bool limitQuality, vector<string> kernelList) {
+    pair<json, json> findTargetKeywords(string key, string mission, bool useWeb, bool searchKernels, bool fullKernelPath, int limitCk, int limitSpk, vector<string> kernelList) {
         
         if (useWeb){
             json args = json::object({
@@ -795,7 +807,8 @@ namespace SpiceQL {
                 {"mission", mission},
                 {"searchKernels", searchKernels},
                 {"fullKernelPath", fullKernelPath},
-                {"limitQuality", limitQuality},
+                {"limitCk", limitCk},
+                {"limitSpk", limitSpk},
                 {"kernelList", kernelList}
             });
             json out = spiceAPIQuery("findTargetKeywords", args);
@@ -806,7 +819,7 @@ namespace SpiceQL {
         json kernelsToLoad = {};
 
         if (mission != "" && searchKernels) {
-            kernelsToLoad = Inventory::search_for_kernelsets({mission, "base"}, {"pck"}, default_StartTime, default_StopTime, default_KernelQualities, default_KernelQualities, fullKernelPath, limitQuality);
+            kernelsToLoad = Inventory::search_for_kernelsets({mission, "base"}, {"pck"}, default_StartTime, default_StopTime, default_KernelQualities, default_KernelQualities, fullKernelPath, limitCk, limitSpk);
         }
 
         if (!kernelList.empty()) {
@@ -820,7 +833,7 @@ namespace SpiceQL {
     }
 
 
-    pair<vector<vector<int>>, json> frameTrace(double et, int initialFrame, string mission, vector<string> ckQualities, vector<string> spkQualities, bool useWeb, bool searchKernels, bool fullKernelPath, bool limitQuality, vector<string> kernelList) {
+    pair<vector<vector<int>>, json> frameTrace(double et, int initialFrame, string mission, vector<string> ckQualities, vector<string> spkQualities, bool useWeb, bool searchKernels, bool fullKernelPath, int limitCk, int limitSpk, vector<string> kernelList) {
         checkNaifErrors();
 
         if (useWeb){
@@ -831,7 +844,8 @@ namespace SpiceQL {
                 {"ckQualities", ckQualities},
                 {"searchKernels", searchKernels},
                 {"fullKernelPath", fullKernelPath},
-                {"limitQuality", limitQuality},
+                {"limitCk", limitCk},
+                {"limitSpk", limitSpk},
                 {"kernelList", kernelList}
             });
             json out = spiceAPIQuery("frameTrace", args);
@@ -842,7 +856,7 @@ namespace SpiceQL {
         json ephemKernels;
 
         if (searchKernels) {
-            ephemKernels = Inventory::search_for_kernelsets({mission, "base"}, {"sclk", "ck", "pck", "fk", "ik", "iak", "lsk", "spk", "tspk"}, et, et, ckQualities, spkQualities, fullKernelPath, limitQuality);
+            ephemKernels = Inventory::search_for_kernelsets({mission, "base"}, {"sclk", "ck", "pck", "fk", "ik", "iak", "lsk", "spk", "tspk"}, et, et, ckQualities, spkQualities, fullKernelPath, limitCk, limitSpk);
         }
 
         if (!kernelList.empty()) {
@@ -971,7 +985,7 @@ namespace SpiceQL {
     }
 
 
-    pair<vector<double>, json> extractExactCkTimes(double observStart, double observEnd, int targetFrame, string mission, vector<string> ckQualities, bool useWeb, bool searchKernels, bool fullKernelPath, bool limitQuality, vector<string> kernelList) {
+    pair<vector<double>, json> extractExactCkTimes(double observStart, double observEnd, int targetFrame, string mission, vector<string> ckQualities, bool useWeb, bool searchKernels, bool fullKernelPath, int limitCk, int limitSpk, vector<string> kernelList) {
         SPDLOG_TRACE("Calling extractExactCkTimes with {}, {}, {}, {}, {}, {}, {}", observStart, observEnd, targetFrame, mission, ckQualities.size(), useWeb, searchKernels);
         
         if (useWeb){
@@ -983,7 +997,8 @@ namespace SpiceQL {
                 {"ckQualities", ckQualities},
                 {"searchKernels", searchKernels},
                 {"fullKernelPath", fullKernelPath},
-                {"limitQuality", limitQuality},
+                {"limitCk", limitCk},
+                {"limitSpk", limitSpk},
                 {"kernelList", kernelList}
             });
             json out = spiceAPIQuery("extractExactCkTimes", args);
@@ -995,7 +1010,7 @@ namespace SpiceQL {
         json ephemKernels = {};
 
         if (searchKernels) {
-            ephemKernels = Inventory::search_for_kernelsets({mission, "base"}, {"ck", "sclk", "lsk"}, observStart, observEnd, ckQualities, {"noquality"}, fullKernelPath, limitQuality);
+            ephemKernels = Inventory::search_for_kernelsets({mission, "base"}, {"ck", "sclk", "lsk"}, observStart, observEnd, ckQualities, {"noquality"}, fullKernelPath, limitCk, limitSpk);
         }
 
         if (!kernelList.empty()) {
@@ -1145,7 +1160,8 @@ namespace SpiceQL {
     }
 
     std::pair<string, nlohmann::json> searchForKernelsets(vector<string> spiceqlNames, vector<string> types, double startTime, double stopTime,
-                                  vector<string> ckQualities, vector<string> spkQualities, bool useWeb, bool fullKernelPath, bool overwrite) { 
+                                  vector<string> ckQualities, vector<string> spkQualities, bool useWeb, bool fullKernelPath, int limitCk, int limitSpk,
+                                  bool overwrite) { 
       if (useWeb){
         json args = json::object({
             {"spiceqlNames", spiceqlNames},
@@ -1155,13 +1171,15 @@ namespace SpiceQL {
             {"ckQualities", ckQualities},
             {"spkQualities", spkQualities},
             {"fullKernelPath", fullKernelPath},
+            {"limitCk", limitCk},
+            {"limitSpk", limitSpk},
             {"overwrite", overwrite}
         });
         json out = spiceAPIQuery("searchForKernelsets", args);
         string kvect = out["body"]["return"];
         return make_pair(kvect, out["body"]["kernels"]);
       }
-      json kernels = Inventory::search_for_kernelsets(spiceqlNames, types, startTime, stopTime, ckQualities, spkQualities, fullKernelPath, overwrite);
+      json kernels = Inventory::search_for_kernelsets(spiceqlNames, types, startTime, stopTime, ckQualities, spkQualities, fullKernelPath, limitCk, limitSpk, overwrite);
       return {"", kernels};
   }
 }

--- a/SpiceQL/src/inventory.cpp
+++ b/SpiceQL/src/inventory.cpp
@@ -20,7 +20,7 @@ namespace SpiceQL {
     namespace Inventory { 
         json search_for_kernelset(string instrument, vector<string> types, double start_time, double stop_time,  
                                   vector<string> ckQualities, vector<string> spkQualities, bool full_kernel_path, 
-                                  bool limit_quality) { 
+                                  int limit_ck, int limit_spk) { 
             InventoryImpl impl;
             
             vector<Kernel::Quality> enum_ck_qualities = Kernel::translateQualities(ckQualities);
@@ -31,12 +31,12 @@ namespace SpiceQL {
                 enum_types.push_back(Kernel::translateType(e));
             }
 
-            return impl.search_for_kernelset(instrument, enum_types, start_time, stop_time, enum_ck_qualities, enum_spk_qualities, full_kernel_path, limit_quality);
+            return impl.search_for_kernelset(instrument, enum_types, start_time, stop_time, enum_ck_qualities, enum_spk_qualities, full_kernel_path, limit_ck, limit_spk);
         }
 
         json search_for_kernelsets(vector<string> spiceql_names, vector<string> types, double start_time, double stop_time, 
                                    vector<string> ckQualities, vector<string> spkQualities, bool full_kernel_path, 
-                                   bool limit_quality, bool overwrite) { 
+                                   int limit_ck, int limit_spk, bool overwrite) { 
             InventoryImpl impl;
               
             vector<Kernel::Quality> enum_ck_qualities = Kernel::translateQualities(ckQualities);
@@ -47,7 +47,7 @@ namespace SpiceQL {
                 enum_types.push_back(Kernel::translateType(e));
             } 
 
-            json kernels = impl.search_for_kernelsets(spiceql_names, enum_types, start_time, stop_time, enum_ck_qualities, enum_spk_qualities, full_kernel_path, limit_quality, overwrite);
+            json kernels = impl.search_for_kernelsets(spiceql_names, enum_types, start_time, stop_time, enum_ck_qualities, enum_spk_qualities, full_kernel_path, limit_ck, limit_spk, overwrite);
             return kernels; 
         }
 

--- a/SpiceQL/tests/InventoryTests.cpp
+++ b/SpiceQL/tests/InventoryTests.cpp
@@ -15,7 +15,7 @@
 
 TEST_F(LroKernelSet, TestInventorySmithed) { 
   Inventory::create_database();
-  nlohmann::json kernels = Inventory::search_for_kernelset("lroc", {"fk", "sclk", "spk", "ck"}, 110000000, 140000000, {"smithed", "reconstructed"}, {"smithed", "reconstructed"}, false, false);
+  nlohmann::json kernels = Inventory::search_for_kernelset("lroc", {"fk", "sclk", "spk", "ck"}, 110000000, 140000000, {"smithed", "reconstructed"}, {"smithed", "reconstructed"}, false);
   SPDLOG_DEBUG("Returned Kernels {} ", kernels.dump());
   
   EXPECT_EQ(fs::path(kernels["fk"][0]).filename(), "lro_frames_1111111_v01.tf");
@@ -30,7 +30,7 @@ TEST_F(LroKernelSet, TestInventorySmithed) {
 
 TEST_F(LroKernelSet, TestInventoryRecon) { 
   Inventory::create_database();
-  nlohmann::json kernels = Inventory::search_for_kernelset("lroc", {"fk", "sclk", "spk", "ck"}, 110000000, 140000000, {"reconstructed"}, {"reconstructed"}, false, false);
+  nlohmann::json kernels = Inventory::search_for_kernelset("lroc", {"fk", "sclk", "spk", "ck"}, 110000000, 140000000, {"reconstructed"}, {"reconstructed"}, false);
   EXPECT_EQ(fs::path(kernels["fk"][0]).filename(), "lro_frames_1111111_v01.tf");
   EXPECT_EQ(fs::path(kernels["sclk"][0]).filename(), "lro_clkcor_2020184_v00.tsc");
   EXPECT_TRUE(!kernels.contains("spk")); // no spks
@@ -75,21 +75,21 @@ TEST_F(LroKernelSet, TestInventoryPortability) {
 
 
 TEST_F(KernelsWithQualities, TestUnenforcedQuality) { 
-  nlohmann::json kernels = Inventory::search_for_kernelset("odyssey", {"spk"}, 130000000, 140000000, {"smithed", "reconstructed"}, {"smithed", "reconstructed"}, false, false);
+  nlohmann::json kernels = Inventory::search_for_kernelset("odyssey", {"spk"}, 130000000, 140000000, {"smithed", "reconstructed"}, {"smithed", "reconstructed"}, false);
   // smithed kernels should not exist so it should return reconstructed
   EXPECT_EQ(kernels["odyssey_spk_quality"].get<string>(), "reconstructed");
 }
 
 
 TEST_F(KernelsWithQualities, TestEnforcedQuality) { 
-  nlohmann::json kernels = Inventory::search_for_kernelset("odyssey", {"spk"}, 130000000, 140000000, {"smithed"}, {"smithed"}, false, true);
+  nlohmann::json kernels = Inventory::search_for_kernelset("odyssey", {"spk"}, 130000000, 140000000, {"smithed"}, {"smithed"}, false);
   // Should be empty since we are enforcing smithed
   EXPECT_TRUE(kernels.is_null());
 }
 
 TEST_F(LroKernelSet, TestInventorySearch) {
   // do a time query
-  nlohmann::json kernels = Inventory::search_for_kernelset("lroc", {"lsk", "sclk", "ck", "spk", "iak", "fk"}, 110000000, 140000001, {"smithed", "reconstructed"}, {"smithed", "reconstructed"}, false, false);
+  nlohmann::json kernels = Inventory::search_for_kernelset("lroc", {"lsk", "sclk", "ck", "spk", "iak", "fk"}, 110000000, 140000001, {"smithed", "reconstructed"}, {"smithed", "reconstructed"}, false);
   SPDLOG_DEBUG("TEST KERNELS: {}", kernels.dump(4));
   EXPECT_EQ(kernels["ck"].size(), 2);
   EXPECT_EQ(fs::path(kernels["ck"][0].get<string>()).filename(), "soc31_1111111_1111111_v21.bc" );
@@ -100,7 +100,7 @@ TEST_F(LroKernelSet, TestInventorySearch) {
 
 TEST_F(LroKernelSet, TestInventorySearchSetsNoOverwrite) {
   // do a time query
-  pair<string, nlohmann::json> result = searchForKernelsets({"moon", "base"}, {"pck"}, 110000000, 140000001, {"reconstructed"}, {"reconstructed"}, false, false);
+  pair<string, nlohmann::json> result = searchForKernelsets({"moon", "base"}, {"pck"}, 110000000, 140000001, {"reconstructed"}, {"reconstructed"}, false);
   nlohmann::json kernels = result.second;
   SPDLOG_DEBUG("TEST KERNELS: {}", kernels.dump(4));
   EXPECT_EQ(kernels["pck"].size(), 2);
@@ -124,7 +124,7 @@ TEST_F(TempTestingFiles, SpiceQLPerformanceInventory) {
 
 TEST_F(LroKernelSet, TestInventorySearchSetsOverwrite) {
   // do a time query
-  pair<string, nlohmann::json> result = searchForKernelsets({"moon", "base"}, {"pck"}, 110000000, 140000001, {"reconstructed"}, {"reconstructed"}, false, false, true);
+  pair<string, nlohmann::json> result = searchForKernelsets({"moon", "base"}, {"pck"}, 110000000, 140000001, {"reconstructed"}, {"reconstructed"}, false, -1, 1, true);
   nlohmann::json kernels = result.second;
   SPDLOG_DEBUG("TEST KERNELS: {}", kernels.dump(4));
   EXPECT_EQ(kernels["pck"].size(), 2);

--- a/fastapi/app/main.py
+++ b/fastapi/app/main.py
@@ -43,7 +43,8 @@ class TargetStatesRequestModel(BaseModel):
     kernelList: Annotated[list[str], Query()] | str | None = []
     searchKernels: bool = True
     fullKernelPath: bool = False
-    limitQuality: bool = False
+    limitCk: int = -1,
+    limitSpk: int = 1
 
 # Create FastAPI instance
 app = FastAPI()
@@ -89,7 +90,8 @@ async def getTargetStates(
     spkQualities: Annotated[list[str], Query()] | str | None = ["smithed", "reconstructed"],
     searchKernels: bool = True,
     fullKernelPath: bool = False,
-    limitQuality: bool = False,
+    limitCk: int = -1,
+    limitSpk: int = 1,
     kernelList: Annotated[list[str], Query()] | str | None = []):
     try:
         if ets is not None:
@@ -107,7 +109,7 @@ async def getTargetStates(
         spkQualities = strToList(spkQualities)
         kernelList = strToList(kernelList)
         print("getTargetStates")
-        result, kernels = pyspiceql.getTargetStates(ets, target, observer, frame, abcorr, mission, ckQualities, spkQualities, False, searchKernels, fullKernelPath, limitQuality, kernelList)
+        result, kernels = pyspiceql.getTargetStates(ets, target, observer, frame, abcorr, mission, ckQualities, spkQualities, False, searchKernels, fullKernelPath, limitCk, limitSpk, kernelList)
         body = ResultModel(result=result, kernels=kernels)
         return ResponseModel(statusCode=200, body=body)
     except Exception as e:
@@ -130,7 +132,8 @@ async def getTargetStates(params: TargetStatesRequestModel):
     spkQualities = params.spkQualities
     searchKernels = params.searchKernels
     fullKernelPath = params.fullKernelPath
-    limitQuality = params.limitQuality
+    limitCk = params.limitCk
+    limitSpk = params.limitSpk
     kernelList = params.kernelList
     try:
         if ets is not None:
@@ -147,7 +150,7 @@ async def getTargetStates(params: TargetStatesRequestModel):
         ckQualities = strToList(ckQualities)
         spkQualities = strToList(spkQualities)
         kernelList = strToList(kernelList)
-        result, kernels = pyspiceql.getTargetStates(ets, target, observer, frame, abcorr, mission, ckQualities, spkQualities, False, searchKernels, fullKernelPath, limitQuality, kernelList)
+        result, kernels = pyspiceql.getTargetStates(ets, target, observer, frame, abcorr, mission, ckQualities, spkQualities, False, searchKernels, fullKernelPath, limitCk, limitSpk, kernelList)
         body = ResultModel(result=result, kernels=kernels)
         return ResponseModel(statusCode=200, body=body)
     except Exception as e:
@@ -167,7 +170,8 @@ async def getTargetOrientations(
     ckQualities: Annotated[list[str], Query()] | str | None = ["smithed", "reconstructed"],
     searchKernels: bool = True,
     fullKernelPath: bool = False,
-    limitQuality: bool = False,
+    limitCk: int = -1,
+    limitSpk: int = 1,
     kernelList: Annotated[list[str], Query()] | str | None = []):
     try:
         if ets is not None:
@@ -183,7 +187,7 @@ async def getTargetOrientations(
             ets = calculate_ets(startEts, stopEts, exposureDuration)
         ckQualities = strToList(ckQualities)
         kernelList = strToList(kernelList)
-        result, kernels = pyspiceql.getTargetOrientations(ets, toFrame, refFrame, mission, ckQualities, False, searchKernels, fullKernelPath, limitQuality, kernelList)
+        result, kernels = pyspiceql.getTargetOrientations(ets, toFrame, refFrame, mission, ckQualities, False, searchKernels, fullKernelPath, limitCk, limitSpk, kernelList)
         body = ResultModel(result=result, kernels=kernels)
         return ResponseModel(statusCode=200, body=body)
     except Exception as e:
@@ -198,11 +202,12 @@ async def strSclkToEt(
     mission: str,
     searchKernels: bool = True,
     fullKernelPath: bool = False,
-    limitQuality: bool = False,
+    limitCk: int = -1,
+    limitSpk: int = 1,
     kernelList: Annotated[list[str], Query()] | str | None = []):
     try:
         kernelList = strToList(kernelList)
-        result, kernels = pyspiceql.strSclkToEt(frameCode, sclk, mission, False, searchKernels, fullKernelPath, limitQuality, kernelList)
+        result, kernels = pyspiceql.strSclkToEt(frameCode, sclk, mission, False, searchKernels, fullKernelPath, limitCk, limitSpk, kernelList)
         body = ResultModel(result=result, kernels=kernels)
         return ResponseModel(statusCode=200, body=body)
     except Exception as e:
@@ -217,11 +222,12 @@ async def doubleSclkToEt(
     mission: str,
     searchKernels: bool = True,
     fullKernelPath: bool = False,
-    limitQuality: bool = False,
+    limitCk: int = -1,
+    limitSpk: int = 1,
     kernelList: Annotated[list[str], Query()] | str | None = []):
     try:
         kernelList = strToList(kernelList)
-        result, kernels = pyspiceql.doubleSclkToEt(frameCode, sclk, mission, False, searchKernels, fullKernelPath, limitQuality, kernelList)
+        result, kernels = pyspiceql.doubleSclkToEt(frameCode, sclk, mission, False, searchKernels, fullKernelPath, limitCk, limitSpk, kernelList)
         body = ResultModel(result=result, kernels=kernels)
         return ResponseModel(statusCode=200, body=body)
     except Exception as e:
@@ -236,11 +242,12 @@ async def doubleEtToSclk(
     mission: str,
     searchKernels: bool = True,
     fullKernelPath: bool = False,
-    limitQuality: bool = False,
+    limitCk: int = -1,
+    limitSpk: int = 1,
     kernelList: Annotated[list[str], Query()] | str | None = []):
     try:
         kernelList = strToList(kernelList)
-        result, kernels = pyspiceql.doubleEtToSclk(frameCode, et, mission, False, searchKernels, fullKernelPath, limitQuality, kernelList)
+        result, kernels = pyspiceql.doubleEtToSclk(frameCode, et, mission, False, searchKernels, fullKernelPath, limitCk, limitSpk, kernelList)
         body = ResultModel(result=result, kernels=kernels)
         return ResponseModel(statusCode=200, body=body)
     except Exception as e:
@@ -253,11 +260,12 @@ async def utcToEt(
     utc: str,
     searchKernels: bool = True,
     fullKernelPath: bool = False,
-    limitQuality: bool = False,
+    limitCk: int = -1,
+    limitSpk: int = 1,
     kernelList: Annotated[list[str], Query()] | str | None = []):
     try:
         kernelList = strToList(kernelList)
-        result, kernels = pyspiceql.utcToEt(utc, False, searchKernels, fullKernelPath, limitQuality, kernelList)
+        result, kernels = pyspiceql.utcToEt(utc, False, searchKernels, fullKernelPath, limitCk, limitSpk, kernelList)
         body = ResultModel(result=result, kernels=kernels)
         return ResponseModel(statusCode=200, body=body)
     except Exception as e:
@@ -271,11 +279,12 @@ async def etToUtc(
     precision: float,
     searchKernels: bool = True,
     fullKernelPath: bool = False,
-    limitQuality: bool = False,
+    limitCk: int = -1,
+    limitSpk: int = 1,
     kernelList: Annotated[list[str], Query()] | str | None = []):
     try:
         kernelList = strToList(kernelList)
-        result, kernels = pyspiceql.etToUtc(et, format, precision, False, searchKernels, fullKernelPath, limitQuality, kernelList)
+        result, kernels = pyspiceql.etToUtc(et, format, precision, False, searchKernels, fullKernelPath, limitCk, limitSpk, kernelList)
         body = ResultModel(result=result, kernels=kernels)
         return ResponseModel(statusCode=200, body=body)
     except Exception as e:
@@ -288,11 +297,12 @@ async def translateNameToCode(
     mission: str,
     searchKernels: bool = True,
     fullKernelPath: bool = False,
-    limitQuality: bool = False,
+    limitCk: int = -1,
+    limitSpk: int = 1,
     kernelList: Annotated[list[str], Query()] | str | None = []):
     try:
         kernelList = strToList(kernelList)
-        result, kernels = pyspiceql.translateNameToCode(frame, mission, False, searchKernels, fullKernelPath, limitQuality, kernelList)
+        result, kernels = pyspiceql.translateNameToCode(frame, mission, False, searchKernels, fullKernelPath, limitCk, limitSpk, kernelList)
         body = ResultModel(result=result, kernels=kernels)
         return ResponseModel(statusCode=200, body=body)
     except Exception as e:
@@ -305,11 +315,12 @@ async def translateCodeToName(
     mission: str,
     searchKernels: bool = True,
     fullKernelPath: bool = False,
-    limitQuality: bool = False,
+    limitCk: int = -1,
+    limitSpk: int = 1,
     kernelList: Annotated[list[str], Query()] | str | None = []):
     try:
         kernelList = strToList(kernelList)
-        result, kernels = pyspiceql.translateCodeToName(frame, mission, False, searchKernels, fullKernelPath, limitQuality, kernelList)
+        result, kernels = pyspiceql.translateCodeToName(frame, mission, False, searchKernels, fullKernelPath, limitCk, limitSpk, kernelList)
         body = ResultModel(result=result, kernels=kernels)
         return ResponseModel(statusCode=200, body=body)
     except Exception as e:
@@ -322,11 +333,12 @@ async def getFrameInfo(
     mission: str,
     searchKernels: bool = True,
     fullKernelPath: bool = False,
-    limitQuality: bool = False,
+    limitCk: int = -1,
+    limitSpk: int = 1,
     kernelList: Annotated[list[str], Query()] | str | None = []):
     try:
         kernelList = strToList(kernelList)
-        result, kernels = pyspiceql.getFrameInfo(frame, mission, False, searchKernels, fullKernelPath, limitQuality, kernelList)
+        result, kernels = pyspiceql.getFrameInfo(frame, mission, False, searchKernels, fullKernelPath, limitCk, limitSpk, kernelList)
         body = ResultModel(result=result, kernels=kernels)
         return ResponseModel(statusCode=200, body=body)
     except Exception as e:
@@ -339,11 +351,12 @@ async def getTargetFrameInfo(
     mission: str,
     searchKernels: bool = True,
     fullKernelPath: bool = False,
-    limitQuality: bool = False,
+    limitCk: int = -1,
+    limitSpk: int = 1,
     kernelList: Annotated[list[str], Query()] | str | None = []):
     try:
         kernelList = strToList(kernelList)
-        result, kernels = pyspiceql.getTargetFrameInfo(targetId, mission, False, searchKernels, fullKernelPath, limitQuality, kernelList)
+        result, kernels = pyspiceql.getTargetFrameInfo(targetId, mission, False, searchKernels, fullKernelPath, limitCk, limitSpk, kernelList)
         body = ResultModel(result=result, kernels=kernels)
         return ResponseModel(statusCode=200, body=body)
     except Exception as e:
@@ -356,11 +369,12 @@ async def findMissionKeywords(
     mission: str,
     searchKernels: bool = True,
     fullKernelPath: bool = False,
-    limitQuality: bool = False,
+    limitCk: int = -1,
+    limitSpk: int = 1,
     kernelList: Annotated[list[str], Query()] | str | None = []):
     try:
         kernelList = strToList(kernelList)
-        result, kernels = pyspiceql.findMissionKeywords(key, mission, False, searchKernels, fullKernelPath, limitQuality, kernelList)
+        result, kernels = pyspiceql.findMissionKeywords(key, mission, False, searchKernels, fullKernelPath, limitCk, limitSpk, kernelList)
         body = ResultModel(result=result, kernels=kernels)
         return ResponseModel(statusCode=200, body=body)
     except Exception as e:
@@ -373,11 +387,12 @@ async def findTargetKeywords(
     mission: str,
     searchKernels: bool = True,
     fullKernelPath: bool = False,
-    limitQuality: bool = False,
+    limitCk: int = -1,
+    limitSpk: int = 1,
     kernelList: Annotated[list[str], Query()] | str | None = []):
     try:
         kernelList = strToList(kernelList)
-        result, kernels = pyspiceql.findTargetKeywords(key, mission, False, searchKernels, fullKernelPath, limitQuality, kernelList)
+        result, kernels = pyspiceql.findTargetKeywords(key, mission, False, searchKernels, fullKernelPath, limitCk, limitSpk, kernelList)
         body = ResultModel(result=result, kernels=kernels)
         return ResponseModel(statusCode=200, body=body)
     except Exception as e:
@@ -393,13 +408,14 @@ async def frameTrace(
     spkQualities: Annotated[list[str], Query()] | str | None = ["smithed", "reconstructed"],
     searchKernels: bool = True,
     fullKernelPath: bool = False,
-    limitQuality: bool = False,
+    limitCk: int = -1,
+    limitSpk: int = 1,
     kernelList: Annotated[list[str], Query()] | str | None = []):
     try:
         ckQualities = strToList(ckQualities)
         spkQualities = strToList(spkQualities)
         kernelList = strToList(kernelList)
-        result, kernels = pyspiceql.frameTrace(et, initialFrame, mission, ckQualities, spkQualities, False, searchKernels, fullKernelPath, limitQuality, kernelList)
+        result, kernels = pyspiceql.frameTrace(et, initialFrame, mission, ckQualities, spkQualities, False, searchKernels, fullKernelPath, limitCk, limitSpk, kernelList)
         body = ResultModel(result=result, kernels=kernels)
         return ResponseModel(statusCode=200, body=body)
     except Exception as e:
@@ -415,12 +431,13 @@ async def extractExactCkTimes(
     ckQualities: Annotated[list[str], Query()] | str | None = ["smithed", "reconstructed"],
     searchKernels: bool = True,
     fullKernelPath: bool = False,
-    limitQuality: bool = False,
+    limitCk: int = -1,
+    limitSpk: int = 1,
     kernelList: Annotated[list[str], Query()] | str | None = []):
     try:
         ckQualities = strToList(ckQualities)
         kernelList = strToList(kernelList)
-        result, kernels = pyspiceql.extractExactCkTimes(observStart, observEnd, targetFrame, mission, ckQualities, False, searchKernels, fullKernelPath, limitQuality, kernelList)
+        result, kernels = pyspiceql.extractExactCkTimes(observStart, observEnd, targetFrame, mission, ckQualities, False, searchKernels, fullKernelPath, limitCk, limitSpk, kernelList)
         body = ResultModel(result=result, kernels=kernels)
         return ResponseModel(statusCode=200, body=body)
     except Exception as e:
@@ -436,13 +453,15 @@ async def searchForKernelsets(
     ckQualities: Annotated[list[str], Query()] | str | None = ["smithed", "reconstructed"],
     spkQualities: Annotated[list[str], Query()] | str | None = ["smithed", "reconstructed"],
     fullKernelPath: bool = False,
+    limitCk: int = -1,
+    limitSpk: int = 1,
     overwrite: bool = False):
     try:
         spiceqlNames = strToList(spiceqlNames)
         types = strToList(types)
         ckQualities = strToList(ckQualities)
         spkQualities = strToList(spkQualities)
-        result, kernels = pyspiceql.searchForKernelsets(spiceqlNames, types, startTime, stopTime, ckQualities, spkQualities, False, fullKernelPath, overwrite)
+        result, kernels = pyspiceql.searchForKernelsets(spiceqlNames, types, startTime, stopTime, ckQualities, spkQualities, False, fullKernelPath, limitCk, limitSpk, overwrite)
         body = ResultModel(result=result, kernels=kernels)
         return ResponseModel(statusCode=200, body=body)
     except Exception as e:

--- a/fastapi/app/main.py
+++ b/fastapi/app/main.py
@@ -43,7 +43,7 @@ class TargetStatesRequestModel(BaseModel):
     kernelList: Annotated[list[str], Query()] | str | None = []
     searchKernels: bool = True
     fullKernelPath: bool = False
-    limitQuality: bool = True
+    limitQuality: bool = False
 
 # Create FastAPI instance
 app = FastAPI()
@@ -89,7 +89,7 @@ async def getTargetStates(
     spkQualities: Annotated[list[str], Query()] | str | None = ["smithed", "reconstructed"],
     searchKernels: bool = True,
     fullKernelPath: bool = False,
-    limitQuality: bool = True,
+    limitQuality: bool = False,
     kernelList: Annotated[list[str], Query()] | str | None = []):
     try:
         if ets is not None:
@@ -167,7 +167,7 @@ async def getTargetOrientations(
     ckQualities: Annotated[list[str], Query()] | str | None = ["smithed", "reconstructed"],
     searchKernels: bool = True,
     fullKernelPath: bool = False,
-    limitQuality: bool = True,
+    limitQuality: bool = False,
     kernelList: Annotated[list[str], Query()] | str | None = []):
     try:
         if ets is not None:
@@ -198,7 +198,7 @@ async def strSclkToEt(
     mission: str,
     searchKernels: bool = True,
     fullKernelPath: bool = False,
-    limitQuality: bool = True,
+    limitQuality: bool = False,
     kernelList: Annotated[list[str], Query()] | str | None = []):
     try:
         kernelList = strToList(kernelList)
@@ -217,7 +217,7 @@ async def doubleSclkToEt(
     mission: str,
     searchKernels: bool = True,
     fullKernelPath: bool = False,
-    limitQuality: bool = True,
+    limitQuality: bool = False,
     kernelList: Annotated[list[str], Query()] | str | None = []):
     try:
         kernelList = strToList(kernelList)
@@ -236,7 +236,7 @@ async def doubleEtToSclk(
     mission: str,
     searchKernels: bool = True,
     fullKernelPath: bool = False,
-    limitQuality: bool = True,
+    limitQuality: bool = False,
     kernelList: Annotated[list[str], Query()] | str | None = []):
     try:
         kernelList = strToList(kernelList)
@@ -253,7 +253,7 @@ async def utcToEt(
     utc: str,
     searchKernels: bool = True,
     fullKernelPath: bool = False,
-    limitQuality: bool = True,
+    limitQuality: bool = False,
     kernelList: Annotated[list[str], Query()] | str | None = []):
     try:
         kernelList = strToList(kernelList)
@@ -271,7 +271,7 @@ async def etToUtc(
     precision: float,
     searchKernels: bool = True,
     fullKernelPath: bool = False,
-    limitQuality: bool = True,
+    limitQuality: bool = False,
     kernelList: Annotated[list[str], Query()] | str | None = []):
     try:
         kernelList = strToList(kernelList)
@@ -288,7 +288,7 @@ async def translateNameToCode(
     mission: str,
     searchKernels: bool = True,
     fullKernelPath: bool = False,
-    limitQuality: bool = True,
+    limitQuality: bool = False,
     kernelList: Annotated[list[str], Query()] | str | None = []):
     try:
         kernelList = strToList(kernelList)
@@ -305,7 +305,7 @@ async def translateCodeToName(
     mission: str,
     searchKernels: bool = True,
     fullKernelPath: bool = False,
-    limitQuality: bool = True,
+    limitQuality: bool = False,
     kernelList: Annotated[list[str], Query()] | str | None = []):
     try:
         kernelList = strToList(kernelList)
@@ -322,7 +322,7 @@ async def getFrameInfo(
     mission: str,
     searchKernels: bool = True,
     fullKernelPath: bool = False,
-    limitQuality: bool = True,
+    limitQuality: bool = False,
     kernelList: Annotated[list[str], Query()] | str | None = []):
     try:
         kernelList = strToList(kernelList)
@@ -339,7 +339,7 @@ async def getTargetFrameInfo(
     mission: str,
     searchKernels: bool = True,
     fullKernelPath: bool = False,
-    limitQuality: bool = True,
+    limitQuality: bool = False,
     kernelList: Annotated[list[str], Query()] | str | None = []):
     try:
         kernelList = strToList(kernelList)
@@ -356,7 +356,7 @@ async def findMissionKeywords(
     mission: str,
     searchKernels: bool = True,
     fullKernelPath: bool = False,
-    limitQuality: bool = True,
+    limitQuality: bool = False,
     kernelList: Annotated[list[str], Query()] | str | None = []):
     try:
         kernelList = strToList(kernelList)
@@ -373,7 +373,7 @@ async def findTargetKeywords(
     mission: str,
     searchKernels: bool = True,
     fullKernelPath: bool = False,
-    limitQuality: bool = True,
+    limitQuality: bool = False,
     kernelList: Annotated[list[str], Query()] | str | None = []):
     try:
         kernelList = strToList(kernelList)
@@ -393,7 +393,7 @@ async def frameTrace(
     spkQualities: Annotated[list[str], Query()] | str | None = ["smithed", "reconstructed"],
     searchKernels: bool = True,
     fullKernelPath: bool = False,
-    limitQuality: bool = True,
+    limitQuality: bool = False,
     kernelList: Annotated[list[str], Query()] | str | None = []):
     try:
         ckQualities = strToList(ckQualities)
@@ -415,7 +415,7 @@ async def extractExactCkTimes(
     ckQualities: Annotated[list[str], Query()] | str | None = ["smithed", "reconstructed"],
     searchKernels: bool = True,
     fullKernelPath: bool = False,
-    limitQuality: bool = True,
+    limitQuality: bool = False,
     kernelList: Annotated[list[str], Query()] | str | None = []):
     try:
         ckQualities = strToList(ckQualities)


### PR DESCRIPTION
~~Before `limitQuality`, all matching cks were returned. Defaulting `limitQuality` to `true` resulted in some errors in ALE's `isd_generate()`. This fix is defaulting `limitQuality` to `false` so it aligns with what was originally implemented.~~

Splitting `limitQuality` into `limitCk` and `limitSpk` to be able to specify per quality kernel. Default `limitCk` is `-1` which retrieves all matching CKs. Default `limitSpk` is `1` which only retrieves the highest priority SPK. If a value inputted is greater than the actual number of matching kernels, SpiceQL will retrieve all kernels (for example, `limitSpk=100` but only 3 matching SPKs so only 3 will return).

Local example: http://127.0.0.1:8080/searchForKernelsets?spiceqlNames=[mro]&types=[ck,spk]&startTime=-1000000000000&stopTime=1000000000000&ckQualities=[smithed,reconstructed]&spkQualities=[smithed,reconstructed]&fullKernelPath=false&limitCk=-1&limitSpk=1&overwrite=false&limitCk=3

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

