### PR TITLE
updated getExactTargetOrientations have proper defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ release.
 
 ## [Unreleased]
 
+- Fixed getExactTargetOrientations using the correct default params 
+
 ## 1.2.1
 
 ### Added

--- a/SpiceQL/include/api.h
+++ b/SpiceQL/include/api.h
@@ -479,14 +479,13 @@ namespace SpiceQL {
         int toFrame, 
         int refFrame, 
         std::string mission, 
-        std::vector<std::string> ckQualities, 
-        bool useWeb, 
-        bool searchKernels, 
-        bool fullKernelPath, 
+        std::vector<std::string> ckQualities={"smithed", "reconstructed"}, 
+        bool useWeb=false, 
+        bool searchKernels=true, 
+        bool fullKernelPath=false, 
         int limitCk=-1, 
         int limitSpk=1,
         std::vector<std::string> kernelList = {});
-
 
     /**
      * @brief Searches for kernels given mission(s) and parameters.


### PR DESCRIPTION
## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [ ] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

