### PR TITLE
`getExactTargetOrientations` Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,9 +35,13 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+- Fixed getExactTargetOrientations to use the correct reference frame when extracting exact times and returned angular velocities when present [#86](https://github.com/DOI-USGS/SpiceQL/pull/86)
+
 ## 1.2.2
 
-- Fixed getExactTargetOrientations using the correct default params 
+### Fixed
+- Fixed getExactTargetOrientations using the correct default params [#84](https://github.com/DOI-USGS/SpiceQL/pull/84)
 
 ## 1.2.1
 

--- a/SpiceQL/src/api.cpp
+++ b/SpiceQL/src/api.cpp
@@ -372,7 +372,7 @@ namespace SpiceQL {
         }
         
         // force searchKernels and useWeb to false
-        auto [exactCkTimes, kernels1] = extractExactCkTimes(startEt, stopEt, toFrame, mission, ckQualities, false, searchKernels, fullKernelPath, 1, 1, kernelList);
+        auto [exactCkTimes, kernels1] = extractExactCkTimes(startEt, stopEt, refFrame, mission, ckQualities, false, searchKernels, fullKernelPath, 1, 1, kernelList);
         SPDLOG_DEBUG("number of exact ck times = {}", exactCkTimes.size());
         auto [orientations, kernels2] = getTargetOrientations(exactCkTimes, toFrame, refFrame, mission, ckQualities, false, searchKernels, fullKernelPath, limitCk, limitSpk, kernelList);
         json ephemKernels = merge_json(kernels1, kernels2);
@@ -381,8 +381,14 @@ namespace SpiceQL {
         vector<vector<double>> ephems;
         size_t n = std::min(exactCkTimes.size(), orientations.size());
         for (size_t i = 0; i < n; ++i) {
-            if (orientations[i].size() >= 4) {
+            if (orientations[i].size() == 4) {
                 vector<double> merged = {exactCkTimes[i], orientations[i][0], orientations[i][1], orientations[i][2], orientations[i][3]};
+                ephems.push_back(merged);
+            }
+            else if (orientations[i].size() > 4) {
+                vector<double> merged = {exactCkTimes[i], 
+                                         orientations[i][0], orientations[i][1], orientations[i][2], orientations[i][3],
+                                         orientations[i][4], orientations[i][5], orientations[i][6]};
                 ephems.push_back(merged);
             }
         }


### PR DESCRIPTION
Fix getExactTargetOrientations frame passing and passed angular velocities if they exist

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

