### PR TITLE
updated Docs for findmission/target keywords

### DIFF
--- a/SpiceQL/include/api.h
+++ b/SpiceQL/include/api.h
@@ -362,16 +362,18 @@ namespace SpiceQL {
 
 
     /**
-    * @brief returns kernel values for a specific mission in the form of a json
+    * @brief returns kernel text keyword values for a specific mission as json
     *
-    *  Takes in a kernel key and returns the value associated with the inputted mission as a json
-    * 
-    * @param key key - Kernel to get values from 
-    * @param mission mission name
+    *  Takes in a kernel key from iaks, iks, and fks and returns the value associated with the input mission (e.g. LRO, MRO, sun etc) as json. 
+    *  findMissionKeywords is a aggregation of cspice's gnpool_c, gcpool_c, gdpool_c, and gipool_c. Input key supports wildcards, e.g. "LRO_*", "*_BORESIGHT_SAMPLE", or "*-8600*". 
+    *  
+    * @param key kernel text keyword to look for 
+    * @param mission spiceql name to search for (e.g. LRO, MRO, sun etc)
     * @param fullKernelPath bool if true returns full kernel paths, default returns relative paths
     * @param limitCk int number of cks to limit to, default is -1 to retrieve all
     * @param limitSpk int number of spks to limit to, default is 1 to retrieve only one
     * @param searchKernels bool Whether to search the kernels for the user
+    * @param kernelList vector of additional kernels to load 
     * @returns json of values
     **/
     std::pair<nlohmann::json, nlohmann::json> findMissionKeywords(
@@ -388,7 +390,8 @@ namespace SpiceQL {
     /**
     * @brief returns Target values in the form of a vector
     *
-    *  Takes in a target and key and returns the value associated in the form of vector.
+    *  Takes in a target and key and returns the value associated in the form of vector from PCKs.
+    *  findTargetKeywords is a aggregation of cspice's gnpool_c, gcpool_c, gdpool_c, and gipool_c. Input key supports wildcards, e.g. "LRO_*", "*_BORESIGHT_SAMPLE", or "*-8600*".
     *  Note: This function is mainly for obtaining target keywords. For obtaining other values, use findMissionKeywords.
     * 
     * @param key keyword for desired values

--- a/SpiceQL/include/api.h
+++ b/SpiceQL/include/api.h
@@ -391,7 +391,7 @@ namespace SpiceQL {
     * @brief returns Target values in the form of a vector
     *
     *  Takes in a target and key and returns the value associated in the form of vector from PCKs.
-    *  findTargetKeywords is a aggregation of cspice's gnpool_c, gcpool_c, gdpool_c, and gipool_c. Input key supports wildcards, e.g. "LRO_*", "*_BORESIGHT_SAMPLE", or "*-8600*".
+    *  findTargetKeywords is a aggregation of cspice's gnpool_c, gcpool_c, gdpool_c, and gipool_c. Input key supports wildcards, e.g. "*_RADII" or "*-8600*".
     *  Note: This function is mainly for obtaining target keywords. For obtaining other values, use findMissionKeywords.
     * 
     * @param key keyword for desired values
@@ -455,7 +455,7 @@ namespace SpiceQL {
      * with segments in a CK file. The times returned are all times assocaited with
      * concrete CK segment times with no interpolation. This function is limited to 
      * loading one CK file at a time, if a time window covers multiple CK files, 
-     * the function will throw an error.
+     * the function will throw an error. For this reason, limitCK is set to 1 by default.
      *
      * @param observStart Ephemeris time to start searching at
      * @param observEnd Ephemeris time to stop searching at

--- a/SpiceQL/include/api.h
+++ b/SpiceQL/include/api.h
@@ -374,7 +374,8 @@ namespace SpiceQL {
     * @param limitSpk int number of spks to limit to, default is 1 to retrieve only one
     * @param searchKernels bool Whether to search the kernels for the user
     * @param kernelList vector of additional kernels to load 
-    * @returns json of values
+    * 
+    * @returns json object of key value pairs
     **/
     std::pair<nlohmann::json, nlohmann::json> findMissionKeywords(
         std::string key, 
@@ -402,7 +403,7 @@ namespace SpiceQL {
     * @param limitSpk int number of spks to limit to, default is 1 to retrieve only one
     * @param kernelList vector<string> vector of additional kernels to load 
     *
-    * @returns vector of values
+    * @returns json object of key value pairs
     **/
     std::pair<nlohmann::json, nlohmann::json> findTargetKeywords(
         std::string key, 


### PR DESCRIPTION
When reviewing the asc-docs PR for exploring the API, I noticed the docstrings for some functions did a bad job of describing how to use it. 


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [ ] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

