### PR TITLE
Fix macosx deploy

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,29 +34,32 @@ build:
 requirements:
 requirements:
   build:
-    - {{ compiler('cxx') }} 
-    - libgcc-ng  # [linux]
-    - libstdcxx-ng  # [linux]
-    - cmake >=3.14
+    - {{ compiler('cxx') }} =18 # [osx]
+    - {{ compiler('cxx') }} # [linux]
     - make
     - swig
-    - fmt >9,<10
-    - spdlog =1.12
+    - cmake-no-system >=3.14
 
   host:
-    - python
     - setuptools
     - cpp-filesystem
     - pip
     - cereal
     - highfive
     - cspice
+    - hdf5
+    - fmt >9,<10
+    - spdlog =1.12
+    - openssl
+    - python
+    - libcurl
+
   run:
+    - python
     - cspice
     - hdf5
     - libcurl
-    - python
-    - uvicorn
+
 
 test:
   imports:


### PR DESCRIPTION
## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

