### PR TITLE
Fix Jons warnings and Update fmt/spdlog

### DIFF
--- a/SpiceQL/src/api.cpp
+++ b/SpiceQL/src/api.cpp
@@ -10,6 +10,7 @@
 
 #include <fmt/format.h>
 #include <fmt/compile.h>
+#include <fmt/ranges.h>
 
 #include <nlohmann/json.hpp>
 #include <spdlog/spdlog.h>

--- a/SpiceQL/src/config.cpp
+++ b/SpiceQL/src/config.cpp
@@ -91,7 +91,7 @@ namespace SpiceQL {
     json::json_pointer pathMod;
     vector<string> deconstructedPointer = {""};
 
-    while (pointer != "") {
+    while (pointer != json::json_pointer("")) {
       deconstructedPointer.push_back(pointer.back());
       pointer.pop_back();
     }
@@ -106,7 +106,7 @@ namespace SpiceQL {
     json::json_pointer fullPointer = pathMod;
 
   // If there is some dependency at the pointer requested, return that instead
-    string depPath = json::json_pointer(getRootDependency(config, fullPointer.to_string()));
+    string depPath = getRootDependency(config, fullPointer.to_string());
     if (depPath != "") {
       return depPath;
     }
@@ -139,11 +139,11 @@ namespace SpiceQL {
       json::json_pointer full_pointer = pointer / json_pointer;
 
       fs::path fsDataPath(dataPath);
-      json::json_pointer kernelPath(getParentPointer(full_pointer, 1));
+      json::json_pointer kernelPath(getParentPointer(full_pointer.to_string(), 1));
       if (fs::exists((string)fsDataPath + kernelPath.to_string())) {
         fsDataPath += kernelPath.to_string();
         kernelPath = json::json_pointer("/kernels");
-        string kernelType = json::json_pointer(getParentPointer(full_pointer, 2)).back();
+        string kernelType = json::json_pointer(getParentPointer(full_pointer.to_string(), 2)).back();
         kernelPath /= kernelType;
         if (fs::exists((string)fsDataPath + kernelPath.to_string())) {
           fsDataPath += kernelPath.to_string();
@@ -174,7 +174,7 @@ namespace SpiceQL {
         pointer = "/" + pointer;
       }
       json::json_pointer p(pointer);
-      res[p] = get(p);
+      res[p] = get(p.to_string());
     }
 
     return res;

--- a/SpiceQL/src/inventoryimpl.cpp
+++ b/SpiceQL/src/inventoryimpl.cpp
@@ -101,7 +101,7 @@ namespace SpiceQL {
       for(auto &subArr : arr) {
         for (auto &kernel : subArr) {
           pair<double, double> sstimes = getKernelStartStopTimes(kernel);
-          SPDLOG_TRACE("{} times: {}, {}", kernel, sstimes.first, sstimes.second); 
+          SPDLOG_TRACE("{} times: {}, {}", std::string(kernel), sstimes.first, sstimes.second); 
           // use start_time as index to the majority of kernels, then use stop time in the value 
           // to get the final list
           size_t index = 0;

--- a/SpiceQL/src/query.cpp
+++ b/SpiceQL/src/query.cpp
@@ -12,7 +12,7 @@
 #include <SpiceUsr.h>
 
 #include <ghc/fs_std.hpp>
-#include <spdlog/spdlog.h>
+#include <fmt/ranges.h>
 
 #include <spdlog/spdlog.h>
 

--- a/SpiceQL/src/spice_types.cpp
+++ b/SpiceQL/src/spice_types.cpp
@@ -10,6 +10,7 @@
 #include <nlohmann/json.hpp>
 
 #include <ghc/fs_std.hpp>
+#include <fmt/ranges.h>
 
 #include <spdlog/spdlog.h>
 

--- a/SpiceQL/src/spiceql.cpp
+++ b/SpiceQL/src/spiceql.cpp
@@ -79,7 +79,7 @@ namespace SpiceQL {
         
         SPDLOG_DEBUG("Using log dir: {}", log_dir); 
         SPDLOG_DEBUG("Log level: {}", log_level_string); 
-        SPDLOG_DEBUG("Log level enum: {}", log_level);
+        SPDLOG_DEBUG("Log level enum: {}", int(log_level));
         SPDLOG_TRACE("Log dir: {}", log_dir);
       } 
     }

--- a/SpiceQL/src/utils.cpp
+++ b/SpiceQL/src/utils.cpp
@@ -19,6 +19,7 @@
 #include <fmt/chrono.h>
 #include <fmt/format.h>
 #include <fmt/compile.h>
+#include <fmt/ranges.h>
 
 #include <nlohmann/json.hpp>
 #include <spdlog/spdlog.h>

--- a/SpiceQL/tests/Fixtures.cpp
+++ b/SpiceQL/tests/Fixtures.cpp
@@ -2,6 +2,7 @@
 #include "Paths.h"
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 #include <spdlog/spdlog.h>
 
 #include <exception>

--- a/SpiceQL/tests/FunctionalTestsConfig.cpp
+++ b/SpiceQL/tests/FunctionalTestsConfig.cpp
@@ -23,40 +23,40 @@ TEST_F(IsisDataDirectory, FunctionalTestConfigEval) {
   int expected_number = 0;
   EXPECT_EQ(SpiceQL::getKernelsAsVector(config_eval_res["clementine1"][pointer]).size(), expected_number);
   EXPECT_EQ(SpiceQL::getKernelsAsVector(pointer_eval_res[pointer]).size(), expected_number);
-  EXPECT_EQ(testConfig["clementine1"][pointer].size(), 1);
+  EXPECT_EQ(testConfig["clementine1"][pointer.to_string()].size(), 1);
 
   pointer = "/ck/smithed/kernels"_json_pointer;
   expected_number = 1;
   EXPECT_EQ(SpiceQL::getKernelsAsVector(config_eval_res["clementine1"][pointer]).size(), expected_number);
   EXPECT_EQ(SpiceQL::getKernelsAsVector(pointer_eval_res[pointer]).size(), expected_number);
-  EXPECT_EQ(testConfig["clementine1"][pointer].size(), expected_number);
+  EXPECT_EQ(testConfig["clementine1"][pointer.to_string()].size(), expected_number);
 
   pointer = "/spk/reconstructed/kernels"_json_pointer;
   expected_number = 0;
   EXPECT_EQ(SpiceQL::getKernelsAsVector(config_eval_res["clementine1"][pointer]).size(), expected_number);
   EXPECT_EQ(SpiceQL::getKernelsAsVector(pointer_eval_res[pointer]).size(), expected_number);
-  EXPECT_EQ(testConfig["clementine1"][pointer].size(), 1);
+  EXPECT_EQ(testConfig["clementine1"][pointer.to_string()].size(), 1);
 
   pointer = "/fk/kernels"_json_pointer;
   expected_number = 3;
   EXPECT_EQ(SpiceQL::getKernelsAsVector(config_eval_res["clementine1"][pointer]).size(), expected_number);
   EXPECT_EQ(SpiceQL::getKernelsAsVector(pointer_eval_res[pointer]).size(), expected_number);
-  EXPECT_EQ(testConfig["clementine1"][pointer].size(), 1);
+  EXPECT_EQ(testConfig["clementine1"][pointer.to_string()].size(), 1);
 
   pointer = "/sclk/kernels"_json_pointer;
   expected_number = 1;
   EXPECT_EQ(SpiceQL::getKernelsAsVector(config_eval_res["clementine1"][pointer]).size(), expected_number);
   EXPECT_EQ(SpiceQL::getKernelsAsVector(pointer_eval_res[pointer]).size(), expected_number);
-  EXPECT_EQ(testConfig["clementine1"][pointer].size(), 1);
+  EXPECT_EQ(testConfig["clementine1"][pointer.to_string()].size(), 1);
 
   pointer = "/uvvis/ik/kernels"_json_pointer;
   expected_number = 1;
   EXPECT_EQ(SpiceQL::getKernelsAsVector(config_eval_res[pointer]).size(), expected_number);
-  EXPECT_EQ(testConfig[pointer].size(), expected_number);
+  EXPECT_EQ(testConfig[pointer.to_string()].size(), expected_number);
 
   pointer = "/uvvis/iak/kernels"_json_pointer;
   expected_number = 4;
   EXPECT_EQ(SpiceQL::getKernelsAsVector(config_eval_res[pointer]).size(), expected_number);
-  EXPECT_EQ(testConfig[pointer].size(), 1);
+  EXPECT_EQ(testConfig[pointer.to_string()].size(), 1);
 }
 

--- a/SpiceQL/tests/MemoTests.cpp
+++ b/SpiceQL/tests/MemoTests.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 #include <ghc/fs_std.hpp>
 #include <chrono>
 

--- a/SpiceQL/tests/QueryTests.cpp
+++ b/SpiceQL/tests/QueryTests.cpp
@@ -2,6 +2,7 @@
 #include <algorithm>
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 #include <gtest/gtest.h>
 #include <spdlog/spdlog.h>
 

--- a/environment.yml
+++ b/environment.yml
@@ -9,9 +9,9 @@ dependencies:
   - cspice 
   - cxx-compiler
   - doxygen
+  - fmt
   - h5py
   - highfive==2.10.1
-  - fmt==9.1.0
   - libhiredis
   - ninja
   - pip
@@ -32,3 +32,4 @@ dependencies:
     - mkdoxy
     - check-jsonschema
     - mkdocs-material
+


### PR DESCRIPTION
Addressed json warnings and fixed for current fmt/spdlog versions

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [ ] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

