### PR TITLE
Support relative kernel paths

### DIFF
--- a/SpiceQL/src/spice_types.cpp
+++ b/SpiceQL/src/spice_types.cpp
@@ -116,6 +116,12 @@ namespace SpiceQL {
   void load(string path, bool force_refurnsh) {
     SPDLOG_DEBUG("Furnishing {}, force refurnish? {}.", path, force_refurnsh); 
     checkNaifErrors();
+    if (fs::path(path).is_absolute()) {
+      SPDLOG_TRACE("path is absolute");
+    } else {
+      SPDLOG_TRACE("path is relative");
+      path = getDataDirectory() / fs::path(path);
+    }
     furnsh_c(path.c_str());
     checkNaifErrors();
   }


### PR DESCRIPTION
Supports relative kernel paths in `load()` for furnishing.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

