### PR TITLE
Externalize alias map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,13 +34,14 @@ release.
 -->
 ### unreleased
 
-### Fixed
+### Changed
+- Refactored the aliasMap variable into a JSON file that can be dynamically loaded and accessed [#120](https://github.com/DOI-USGS/SpiceQL/pull/120)
 
+### Fixed
 - Fixed API list parsing when input is a string [#110](https://github.com/DOI-USGS/SpiceQL/pull/110)
 - Fixed getTargetStates failure when query was too long for a GET Request [#114](https://github.com/DOI-USGS/SpiceQL/pull/114)
 
 ### Added
-
 - Added getTargetStatesRanged so a request can be made with start, end, and range of ETs instead of a list [#115](https://github.com/DOI-USGS/SpiceQL/pull/115)
 - Added option to json2DIntArrayTo2DVector to retain empty subarrays rather than remove them [#117](https://github.com/DOI-USGS/SpiceQL/pull/117)
 - Added support for ISD to kernel generation [#116](https://github.com/DOI-USGS/SpiceQL/pull/116)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,8 @@ if(SPICEQL_BUILD_LIB)
                           ${CMAKE_CURRENT_SOURCE_DIR}/SpiceQL/src/config.cpp
                           ${CMAKE_CURRENT_SOURCE_DIR}/SpiceQL/src/inventory.cpp
                           ${CMAKE_CURRENT_SOURCE_DIR}/SpiceQL/src/inventoryimpl.cpp
-                          ${CMAKE_CURRENT_SOURCE_DIR}/SpiceQL/src/api.cpp)
+                          ${CMAKE_CURRENT_SOURCE_DIR}/SpiceQL/src/api.cpp
+                          ${CMAKE_CURRENT_SOURCE_DIR}/SpiceQL/src/alias_map.cpp)
 
 
   set(SPICEQL_HEADER_FILES ${SPICEQL_BUILD_INCLUDE_DIR}/spiceql.h
@@ -84,10 +85,13 @@ if(SPICEQL_BUILD_LIB)
                            ${SPICEQL_BUILD_INCLUDE_DIR}/config.h
                            ${SPICEQL_BUILD_INCLUDE_DIR}/inventory.h
                            ${SPICEQL_BUILD_INCLUDE_DIR}/inventoryimpl.h
-                           ${SPICEQL_BUILD_INCLUDE_DIR}/api.h)
+                           ${SPICEQL_BUILD_INCLUDE_DIR}/api.h
+                           ${SPICEQL_BUILD_INCLUDE_DIR}/alias_map.h)
 
   set(SPICEQL_PRIVATE_HEADER_FILES ${SPICEQL_BUILD_INCLUDE_DIR}/memo.h
                                    ${SPICEQL_BUILD_INCLUDE_DIR}/restincurl.h)
+
+  set(SPICEQL_ALIASMAP_FILE ${CMAKE_CURRENT_SOURCE_DIR}/SpiceQL/aliasMap.json)
 
   set(SPICEQL_CONFIG_FILES ${CMAKE_CURRENT_SOURCE_DIR}/SpiceQL/db/apollo15.json 
                            ${CMAKE_CURRENT_SOURCE_DIR}/SpiceQL/db/apollo16.json
@@ -174,6 +178,9 @@ target_include_directories(SpiceQL
 
   # Install the headers
   install(FILES ${SPICEQL_HEADER_FILES} DESTINATION ${SPICEQL_INSTALL_INCLUDE_DIR})
+
+  # Install the json db files
+  install(FILES ${SPICEQL_ALIASMAP_FILE} DESTINATION "etc/SpiceQL")
 
   # Install the json db files
   install(FILES ${SPICEQL_CONFIG_FILES} DESTINATION "etc/SpiceQL/db")

--- a/SpiceQL/aliasMap.json
+++ b/SpiceQL/aliasMap.json
@@ -1,0 +1,221 @@
+{
+    "amica": [
+        "AMICA",
+        "HAYABUSA_AMICA"
+    ],
+    "apollo15_metric": [
+        "A15_METRIC"
+    ],
+    "apollo15_panoramic": [
+        "APOLLO15_APOLLO PANORAMIC CAMERA"
+    ],
+    "cassini": [
+        "CASSINI_ISS_NAC",
+        "CASSINI_ISS_WAC",
+        "CASSINI_VIMS_V",
+        "Cassini-Huygens"
+    ],
+    "cassis": [
+        "TGO_CASSIS",
+        "TGO_CASSIS_CRU"
+    ],
+    "chandrayaan2": [
+        "CH2",
+        "CH-2"
+    ],
+    "clementine1": [
+        "High Resolution Camera",
+        "Long Wave Infrared Camera",
+        "CLEM_HIRES",
+        "CLEM_LWIR"
+    ],
+    "crism": [
+        "MRO_CRISM_VNIR"
+    ],
+    "ctx": [
+        "CONTEXT CAMERA",
+        "MRO_CTX"
+    ],
+    "fc2": [
+        "DAWN_FC2_FILTER_1",
+        "DAWN_FC2_FILTER_2",
+        "DAWN_FC2_FILTER_3",
+        "DAWN_FC2_FILTER_4",
+        "DAWN_FC2_FILTER_5",
+        "DAWN_FC2_FILTER_6",
+        "DAWN_FC2_FILTER_7",
+        "DAWN_FC2_FILTER_8"
+    ],
+    "galileo": [
+        "GLL_SSI_PLATFORM"
+    ],
+    "hirise": [
+        "MRO_HIRISE",
+        "MRO_HIRISE_LOOK_DIRECTION"
+    ],
+    "hrsc": [
+        "MEX_HRSC_HEAD",
+        "MEX_HRSC_IR"
+    ],
+    "juno": [
+        "JUNO_JUNOCAM"
+    ],
+    "kaguya": [
+        "LISM_MI-VIS1",
+        "LISM_MI-VIS2",
+        "LISM_MI-VIS3",
+        "LISM_MI-VIS4",
+        "LISM_MI-VIS5",
+        "LISM_MI-NIR1",
+        "LISM_MI-NIR2",
+        "LISM_MI-NIR3",
+        "LISM_MI-NIR4",
+        "LISM_TC1_WDF",
+        "LISM_TC1_WTF",
+        "LISM_TC1_SDF",
+        "LISM_TC1_STF",
+        "LISM_TC1_WDN",
+        "LISM_TC1_WTN",
+        "LISM_TC1_SDN",
+        "LISM_TC1_STN",
+        "LISM_TC1_WDH",
+        "LISM_TC1_WTH",
+        "LISM_TC1_SDH",
+        "LISM_TC1_STH",
+        "LISM_TC1_SSH",
+        "SELENE",
+        "KAGUYA",
+        "SELENE MAIN ORBITER"
+    ],
+    "leisa": [
+        "NH_RALPH_LEISA",
+        "ISIS_NH_RALPH_LEISA"
+    ],
+    "lo": [
+        "LO1_HIGH_RESOLUTION_CAMERA",
+        "LO2_HIGH_RESOLUTION_CAMERA",
+        "LO3_HIGH_RESOLUTION_CAMERA",
+        "LO4_HIGH_RESOLUTION_CAMERA",
+        "LO5_HIGH_RESOLUTION_CAMERA",
+        "LO3_MED_RESOLUTION_CAMERA"
+    ],
+    "lorri": [
+        "NH_LORRI",
+        "NH_LORRI_1X1"
+    ],
+    "lroc": [
+        "LRO_LROCNACL",
+        "LRO_LROCNACR",
+        "LRO_LROCWAC_UV",
+        "LRO_LROCWAC_VIS"
+    ],
+    "m10_vidicon_a": [
+        "M10_VIDICON_A",
+        "VIDICON_A"
+    ],
+    "m10_vidicon_b": [
+        "M10_VIDICON_B"
+    ],
+    "m3": [
+        "CHANDRAYAAN-1_M3"
+    ],
+    "marci": [
+        "MRO_MARCI_VIS",
+        "MRO_MARCI_UV",
+        "MRO_MARCI_BASE"
+    ],
+    "mdis": [
+        "MSGR_MDIS_WAC",
+        "MSGR_MDIS_NAC",
+        "MERCURY DUAL IMAGING SYSTEM NARROW ANGLE CAMERA"
+    ],
+    "mgs": [
+        "MGS_MOC_NA",
+        "MGS_MOC_WA_RED",
+        "MGS_MOC_WA_BLUE"
+    ],
+    "minirf": [
+        "LRO_MINIRF"
+    ],
+    "mrffr": [
+        "CHANDRAYAAN-1_MRFFR"
+    ],
+    "mro": [
+        "MARS"
+    ],
+    "msi": [
+        "NEAR_MSI"
+    ],
+    "msl": [
+        "MSL_MASTCAM_LEFT"
+    ],
+    "mvic_framing": [
+        "ISIS_NH_RALPH_MVIC_METHANE",
+        "ISIS_NH_RALPH_MVIC_FT"
+    ],
+    "mvic_tdi": [
+        "NH_MVIC"
+    ],
+    "near": [
+        "NEAR EARTH ASTEROID RENDEZVOUS"
+    ],
+    "nir": [
+        "Near Infrared Camera",
+        "CLEM_NIR"
+    ],
+    "nirs": [
+        "HAYABUSA_NIRS"
+    ],
+    "odyssey": [
+        "M01_THEMIS_IR",
+        "M01_THEMIS_VIS",
+        "THEMIS_IR",
+        "THEMIS_VIS"
+    ],
+    "ohrc": [
+        "CH2_OHRC"
+    ],
+    "onc": [
+        "HAYABUSA2_ONC"
+    ],
+    "src": [
+        "MEX_HRSC_SRC"
+    ],
+    "tmc2": [
+        "CH2_TMC_NADIR"
+    ],
+    "uvvis": [
+        "ULTRAVIOLET/VISIBLE CAMERA",
+        "CLEM_UVVIS_A"
+    ],
+    "viking1": [
+        "VIKING ORBITER 1",
+        "VIKING_ORBITER_1",
+        "VO1_VISA",
+        "VO1_VISB"
+    ],
+    "viking2": [
+        "VIKING ORBITER 2",
+        "VIKING_ORBITER_2",
+        "VO2_VISB",
+        "VO2_VISA"
+    ],
+    "vir": [
+        "DAWN_VIR_IR",
+        "Visual and Infrared Spectrometer"
+    ],
+    "virtis": [
+        "ROS_VIRTIS-M_IR"
+    ],
+    "voyager1": [
+        "JUPITER",
+        "NEPTUNE",
+        "SATURN",
+        "VG1_ISSNA",
+        "VG1_ISSWA"
+    ],
+    "voyager2": [
+        "VG2_ISSNA",
+        "VG2_ISSWA"
+    ]
+}

--- a/SpiceQL/include/alias_map.h
+++ b/SpiceQL/include/alias_map.h
@@ -1,0 +1,28 @@
+#pragma once
+#include <string>
+#include <nlohmann/json.hpp>
+
+namespace SpiceQL {
+
+    /**
+     * @brief Load alias map given path or defaults to aliasMap.json in env
+     * 
+     * @param path string path to json file
+     */
+    void load_aliases(std::string path = ""); 
+
+    /**
+     * @brief Get SpiceQL mission given alias
+     * 
+     * @param alias string alias name
+     * @return string mission name
+     */
+    std::string get_mission(const std::string& alias);
+
+    /**
+     * @brief Get aliases as map
+     * 
+     * @return JSON map of aliases
+     */
+    nlohmann::json get_aliases();
+}

--- a/SpiceQL/include/alias_map.h
+++ b/SpiceQL/include/alias_map.h
@@ -1,28 +1,83 @@
 #pragma once
 #include <string>
+#include <unordered_map>
+#include <mutex>
 #include <nlohmann/json.hpp>
 
 namespace SpiceQL {
 
-    /**
-     * @brief Load alias map given path or defaults to aliasMap.json in env
-     * 
-     * @param path string path to json file
-     */
-    void load_aliases(std::string path = ""); 
+  class AliasMap {
+    public:
+      /**
+       * @brief Accessor for AliasMap instance
+       * 
+       * @return A reference to the global AliasMap instance
+       */
+      static AliasMap& instance();
 
-    /**
-     * @brief Get SpiceQL mission given alias
-     * 
-     * @param alias string alias name
-     * @return string mission name
-     */
-    std::string get_mission(const std::string& alias);
+      /**
+       * @brief Loads an alias map from a JSON file path
+       * 
+       * @param path Filesystem path to the JSON file 
+       */
+      void load(std::string path);
 
-    /**
-     * @brief Get aliases as map
-     * 
-     * @return JSON map of aliases
-     */
-    nlohmann::json get_aliases();
+      /**
+       * @brief Gets SpiceQL name given alias or frame name
+       * 
+       * @param name Given string name to look up
+       * @return The SpiceQL name or empty string if not found
+       */
+      std::string getSpiceqlName(const std::string& name);
+
+      /**
+       * @brief Adds an alias to the lookup table for the given SpiceQL name
+       * 
+       * @param alias Alias string for SpiceQL name
+       * @param spiceqlName The target SpiceQL name
+       */
+      void addAliasKey(const std::string &alias, const std::string &spiceqlName);
+
+      /**
+       * @brief Retrieves the alias map lookup table as JSON object
+       * 
+       * @return A JSON object where keys are SpiceQL names and the values are an array of aliases
+       */
+      nlohmann::json getAliasMap();
+
+      /**
+       * @brief Overwrites the current lookup table with a user-provided JSON object
+       * 
+       * @param newAliasMap The alias map as a JSON object
+       */
+      void setAliasMap(const nlohmann::json& newAliasMap);
+
+    private:
+      AliasMap() = default; // Prevents others from making new instances
+
+      /**
+       * @brief Checks initialization status and loads default aliases if necessary
+       */
+      void ensure_init();
+
+      /**
+       * @brief Internal logic for parsing JSON and populating the lookup table without locking
+       * 
+       * @param path Path to the JSON file to load
+       */
+      void load_internal(std::string path);
+
+      // These live inside the class so the Singleton "owns" them
+      std::unordered_map<std::string, std::string> m_lookupTable;
+      std::mutex m_mutex;
+      bool m_initialized = false;
+  };
+
+  /**
+   * @brief Free function to trigger loading aliases
+   * 
+   * @param path Optional path to a specific JSON file
+   */
+  void load_aliases(std::string path = "");
+
 }

--- a/SpiceQL/include/api.h
+++ b/SpiceQL/include/api.h
@@ -6,9 +6,57 @@
 
 namespace SpiceQL {
 
+    /**
+     * @brief Translates a given name using the aliasMap and checks if the name is in the frameList.
+     * 
+     * If the name exists as a key in aliasMap, returns the mapped value.
+     * If the name exists in frameList, returns the name itself.
+     * Otherwise, returns an empty string.
+     * 
+     * @param name The name to translate.
+     * @param frameList The list of valid frame names.
+     * @return The translated name or an empty string if not found.
+     */
     std::string getSpiceqlName(const std::string& name);
+
+    /**
+     * @brief Adds or updates a key-value pair in the aliasMap.
+     * 
+     * @param key The key to add or update.
+     * @param value The value to associate with the key.
+     */
+    void addAliasKey(const std::string& key, const std::string& value);
+
+    /**
+     * @brief Accessor for the aliasMap.
+     * 
+     * @return const reference to the aliasMap JSON object.
+     */
+    nlohmann::json getAliasMap();
+
+    /**
+     * @brief Setter for the aliasMap.
+     * 
+     * @param newAliasMap The new JSON object to set as the aliasMap.
+     */
+    void setAliasMap(const nlohmann::json& newAliasMap);
     
+    /**
+     * @brief URL encodes a given string.
+     * 
+     * @param value The string to encode.
+     * @return The encoded string.
+     */
     std::string url_encode(const std::string &value);
+
+    /**
+     * @brief Query implementation for SpiceQL's REST API
+     * 
+     * @param functionName SpiceQL's REST API endpoint name
+     * @param args Endpoint query params as json
+     * @param method REST HTTP method type as string
+     * @return Response payload as json
+     */
     nlohmann::json spiceAPIQuery(std::string functionName, nlohmann::json args, std::string method="GET");
     
     /**

--- a/SpiceQL/include/api.h
+++ b/SpiceQL/include/api.h
@@ -6,33 +6,6 @@
 
 namespace SpiceQL {
 
-    extern nlohmann::json aliasMap;
-    
-    /**
-     * @brief Accessor for the aliasMap.
-     * @return const reference to the aliasMap JSON object.
-     */
-    inline const nlohmann::json& getAliasMap() {
-        return aliasMap;
-    }
-
-
-    /**
-     * @brief Adds or updates a key-value pair in the aliasMap.
-     * @param key The key to add or update.
-     * @param value The value to associate with the key.
-     */
-    void addAliasKey(const std::string& key, const std::string& value);
-
-    
-    /**
-     * @brief Setter for the aliasMap.
-     * @param newAliasMap The new JSON object to set as the aliasMap.
-     */
-    inline void setAliasMap(const nlohmann::json& newAliasMap) {
-        aliasMap = newAliasMap;
-    }
-
     std::string getSpiceqlName(const std::string& name);
     
     std::string url_encode(const std::string &value);

--- a/SpiceQL/include/utils.h
+++ b/SpiceQL/include/utils.h
@@ -505,4 +505,11 @@ namespace SpiceQL {
    * @param mission mission name of the config file
    */
   nlohmann::json loadSelectKernels(std::string kernelType, std::string mission);
+
+  /**
+   * @brief Gets default path for JSON file of aliases
+   * 
+   * @returns string file path 
+   */
+  std::string getAliasMapJsonFile();
 }

--- a/SpiceQL/src/alias_map.cpp
+++ b/SpiceQL/src/alias_map.cpp
@@ -1,4 +1,5 @@
 #include "alias_map.h"
+#include "config.h"
 #include "utils.h"
 #include <mutex>
 #include <unordered_map>
@@ -10,64 +11,108 @@ using namespace std;
 
 namespace SpiceQL {
 
-    // internal
-    static unordered_map<string, string> m_lookupTable;
-    static mutex m_mutex;
-    static bool m_initialized = false;
+  AliasMap& AliasMap::instance() {
+    static AliasMap inst;
+    return inst;
+  }
 
-    void load_aliases_internal(string path) {
-      if (path.empty()) {
-        path = getAliasMapJsonFile();
+  void AliasMap::ensure_init() {
+    if (!m_initialized) {
+      SPDLOG_DEBUG("Loading default aliases.");
+      load_internal(""); 
+    }
+  }
+
+  void load_aliases(string path) {
+    AliasMap::instance().load(path);
+  }
+
+  void AliasMap::load_internal(string path) {    
+    if (path.empty()) {
+      path = getAliasMapJsonFile(); 
+    }
+
+    SPDLOG_INFO("Loading aliases from {}", path);
+    ifstream file(path);
+    if (!file.is_open()) {
+      throw runtime_error("Failed to open alias file: " + path);
+    }
+
+    nlohmann::json j;
+    file >> j;
+
+    m_lookupTable.clear();
+    for (auto& [mission, aliases] : j.items()) {
+      for (const string& alias : aliases) {
+        m_lookupTable[toUpper(alias)] = mission;
       }
+    }
+    
+    m_initialized = true;
+  }
 
-      SPDLOG_INFO("Loading aliases from {}", path);
-      ifstream file(path);
-      if (!file.is_open()) {
-        throw runtime_error("Failed to open alias file: " + path);
-      }
+  void AliasMap::load(string path) {
+    lock_guard<mutex> lock(m_mutex);
+    load_internal(path);
+  }
 
-      json j;
-      file >> j;
+  string AliasMap::getSpiceqlName(const string& name) {
+    lock_guard<mutex> lock(m_mutex);
+    ensure_init();
 
-      m_lookupTable.clear();
-      for (auto& [mission, aliases] : j.items()) {
-        for (const string& alias : aliases) {
-          m_lookupTable[toUpper(alias)] = mission;
+    string upperAlias = toUpper(name);
+    auto it = m_lookupTable.find(upperAlias);
+    if (it != m_lookupTable.end()) {
+        return it->second;
+    }
+
+    // Fallback: check frameList()
+    for (const auto& frame : frameList()) {
+        if (frame == name) return name;
+    }
+    
+    return "";
+  }
+
+  void AliasMap::addAliasKey(const std::string &alias, const std::string &spiceqlName) {
+    lock_guard<mutex> lock(m_mutex);
+    ensure_init();
+    m_lookupTable[toUpper(alias)] = spiceqlName;
+  }
+
+  nlohmann::json AliasMap::getAliasMap() {
+    lock_guard<mutex> lock(m_mutex);
+    ensure_init();
+
+    // Unflatten and reformat as original JSON formatting
+    nlohmann::json aliasMapJson;
+    for (auto const& [alias, key] : m_lookupTable) {
+      aliasMapJson[key].push_back(alias);
+    }
+    return aliasMapJson;
+  }
+
+  void AliasMap::setAliasMap(const nlohmann::json& newAliasMap) {
+    lock_guard<mutex> lock(m_mutex);
+    
+    m_lookupTable.clear();
+
+    if (!newAliasMap.is_object()) {
+      throw runtime_error("Provided alias map must be a JSON object.");
+    }
+
+    for (auto& [mission, aliases] : newAliasMap.items()) {
+      if (aliases.is_array()) {
+        for (const auto& alias_val : aliases) {
+          if (alias_val.is_string()) {
+            m_lookupTable[toUpper(alias_val.get<string>())] = mission;
+          }
         }
       }
-      
-      m_initialized = true;
-      SPDLOG_INFO("Successfully loaded {} aliases into memory.", m_lookupTable.size());
     }
+    
+    m_initialized = true; 
+    SPDLOG_INFO("Alias map manually updated with {} entries.", m_lookupTable.size());
+  }
 
-    void ensure_init() {
-      if (!m_initialized) {
-        SPDLOG_DEBUG("Loading default aliases.");
-        load_aliases_internal(""); 
-      }
-    }
-
-    // public
-    void load_aliases(string path) {
-      lock_guard<mutex> lock(m_mutex);
-      load_aliases_internal(path); 
-    }
-
-    string get_mission(const string& alias) {
-      lock_guard<mutex> lock(m_mutex);
-      ensure_init();
-
-      string upperAlias = toUpper(alias);
-      auto it = m_lookupTable.find(upperAlias);
-      if (it != m_lookupTable.end()) {
-        return it->second;
-      }
-      throw invalid_argument("Alias [" + alias + "] not found.");
-    }
-
-    json get_aliases() {
-      lock_guard<mutex> lock(m_mutex);
-      ensure_init();
-      return m_lookupTable;
-    }
 }

--- a/SpiceQL/src/alias_map.cpp
+++ b/SpiceQL/src/alias_map.cpp
@@ -1,0 +1,73 @@
+#include "alias_map.h"
+#include "utils.h"
+#include <mutex>
+#include <unordered_map>
+#include <fstream>
+#include <spdlog/spdlog.h>
+
+using json = nlohmann::json;
+using namespace std;
+
+namespace SpiceQL {
+
+    // internal
+    static unordered_map<string, string> m_lookupTable;
+    static mutex m_mutex;
+    static bool m_initialized = false;
+
+    void load_aliases_internal(string path) {
+      if (path.empty()) {
+        path = getAliasMapJsonFile();
+      }
+
+      SPDLOG_INFO("Loading aliases from {}", path);
+      ifstream file(path);
+      if (!file.is_open()) {
+        throw runtime_error("Failed to open alias file: " + path);
+      }
+
+      json j;
+      file >> j;
+
+      m_lookupTable.clear();
+      for (auto& [mission, aliases] : j.items()) {
+        for (const string& alias : aliases) {
+          m_lookupTable[toUpper(alias)] = mission;
+        }
+      }
+      
+      m_initialized = true;
+      SPDLOG_INFO("Successfully loaded {} aliases into memory.", m_lookupTable.size());
+    }
+
+    void ensure_init() {
+      if (!m_initialized) {
+        SPDLOG_DEBUG("Loading default aliases.");
+        load_aliases_internal(""); 
+      }
+    }
+
+    // public
+    void load_aliases(string path) {
+      lock_guard<mutex> lock(m_mutex);
+      load_aliases_internal(path); 
+    }
+
+    string get_mission(const string& alias) {
+      lock_guard<mutex> lock(m_mutex);
+      ensure_init();
+
+      string upperAlias = toUpper(alias);
+      auto it = m_lookupTable.find(upperAlias);
+      if (it != m_lookupTable.end()) {
+        return it->second;
+      }
+      throw invalid_argument("Alias [" + alias + "] not found.");
+    }
+
+    json get_aliases() {
+      lock_guard<mutex> lock(m_mutex);
+      ensure_init();
+      return m_lookupTable;
+    }
+}

--- a/SpiceQL/src/api.cpp
+++ b/SpiceQL/src/api.cpp
@@ -33,42 +33,22 @@ namespace SpiceQL {
     double default_StopTime = std::numeric_limits<double>::max();
     vector<string> default_KernelQualities = {"smithed", "reconstructed"};
     
-    /**
-     * @brief Translates a given name using the aliasMap and checks if the name is in the frameList.
-     * 
-     * If the name exists as a key in aliasMap, returns the mapped value.
-     * If the name exists in frameList, returns the name itself.
-     * Otherwise, returns an empty string.
-     * 
-     * @param name The name to translate.
-     * @param frameList The list of valid frame names.
-     * @return The translated name or an empty string if not found.
-     */
     std::string getSpiceqlName(const std::string& name) {
-        try {
-            return get_mission(name);
-        } catch (invalid_argument e) {
-            SPDLOG_INFO("Unable to get SpiceQL name from aliases: {}", e.what());
-
-            // Check if name is in frameList
-            for (const auto& frame : frameList()) {
-                if (frame == name) {
-                    return name;
-                }
-            }
-        }
-
-        // Not found
-        return "";
+        return AliasMap::instance().getSpiceqlName(name);
     }
 
+    void addAliasKey(const std::string& key, const std::string& value) {
+        AliasMap::instance().addAliasKey(key, value);
+    }
+
+    nlohmann::json getAliasMap() {
+        return AliasMap::instance().getAliasMap();
+    }
+
+    void setAliasMap(const nlohmann::json& newAliasMap) {
+        AliasMap::instance().setAliasMap(newAliasMap);
+    }
     
-    /**
-     * @brief URL encodes a given string.
-     * 
-     * @param value The string to encode.
-     * @return The encoded string.
-     */
     std::string url_encode(const std::string &value) {
         std::ostringstream escaped;
         escaped.fill('0');

--- a/SpiceQL/src/api.cpp
+++ b/SpiceQL/src/api.cpp
@@ -22,6 +22,7 @@
 #include "api.h"
 #include "restincurl.h"
 #include "config.h"
+#include "alias_map.h"
 
 using json = nlohmann::json;
 using namespace std;
@@ -31,134 +32,6 @@ namespace SpiceQL {
     double default_StartTime = -std::numeric_limits<double>::max();
     double default_StopTime = std::numeric_limits<double>::max();
     vector<string> default_KernelQualities = {"smithed", "reconstructed"};
-
-    json aliasMap = {
-      {"A15_METRIC", "apollo15_metric"},
-      {"APOLLO15_APOLLO PANORAMIC CAMERA", "apollo15_panoramic"},
-      {"AMICA", "amica"},
-      {"CHANDRAYAAN-1_M3", "m3"},
-      {"CHANDRAYAAN-1_MRFFR", "mrffr"},
-      {"CASSINI_ISS_NAC", "cassini"},
-      {"CASSINI_ISS_WAC", "cassini"},
-      {"CASSINI_VIMS_V", "cassini"},
-      {"Cassini-Huygens", "cassini"},
-      {"CONTEXT CAMERA", "ctx"},
-      {"DAWN_FC2_FILTER_1", "fc2"},
-      {"DAWN_FC2_FILTER_2", "fc2"},
-      {"DAWN_FC2_FILTER_3", "fc2"},
-      {"DAWN_FC2_FILTER_4", "fc2"},
-      {"DAWN_FC2_FILTER_5", "fc2"},
-      {"DAWN_FC2_FILTER_6", "fc2"},
-      {"DAWN_FC2_FILTER_7", "fc2"},
-      {"DAWN_FC2_FILTER_8", "fc2"},
-      {"DAWN_VIR_IR", "vir"},
-      {"GLL_SSI_PLATFORM", "galileo"},
-      {"HAYABUSA_AMICA", "amica"},
-      {"HAYABUSA_NIRS", "nirs"},
-      {"HAYABUSA2_ONC-W2", "onc"},
-      {"JUNO_JUNOCAM", "juno"},
-      {"JUPITER", "voyager1"},
-      {"LRO_LROCNACL", "lroc"},
-      {"LRO_LROCNACR", "lroc"},
-      {"LRO_LROCWAC_UV", "lroc"},
-      {"LRO_LROCWAC_VIS", "lroc"},
-      {"LRO_MINIRF", "minirf"},
-      {"M10_VIDICON_A", "m10_vidicon_a"},
-      {"M10_VIDICON_B", "m10_vidicon_b"},
-      {"VIDICON_A", "m10_vidicon_a"},
-      {"MARS", "mro"},
-      {"MSGR_MDIS_WAC", "mdis"},
-      {"MSGR_MDIS_NAC", "mdis"},
-      {"MERCURY DUAL IMAGING SYSTEM NARROW ANGLE CAMERA", "mdis"},
-      {"MEX_HRSC_HEAD", "hrsc"},
-      {"MEX_HRSC_SRC", "src"},
-      {"MEX_HRSC_IR", "hrsc"},
-      {"MGS_MOC_NA", "mgs"},
-      {"MGS_MOC_WA_RED", "mgs"},
-      {"MGS_MOC_WA_BLUE", "mgs"},
-      {"MRO_MARCI_VIS", "marci"},
-      {"MRO_MARCI_UV", "marci"},
-      {"MRO_MARCI_BASE", "marci"},
-      {"MRO_CTX", "ctx"},
-      {"MRO_HIRISE", "hirise"},
-      {"MRO_HIRISE_LOOK_DIRECTION", "hirise"},
-      {"MRO_CRISM_VNIR", "crism"},
-      {"NEAR EARTH ASTEROID RENDEZVOUS", "near"},
-      {"NEAR_MSI", "msi"},
-      {"NH_LORRI", "lorri"},
-      {"NH_LORRI_1X1", "lorri"},
-      {"NH_RALPH_LEISA", "leisa"},
-      {"NH_MVIC", "mvic_tdi"},
-      {"ISIS_NH_RALPH_LEISA", "leisa"},
-      {"ISIS_NH_RALPH_MVIC_METHANE", "mvic_framing"},
-      {"ISIS_NH_RALPH_MVIC_FT", "mvic_framing"},
-      {"M01_THEMIS_IR", "odyssey"},
-      {"M01_THEMIS_VIS", "odyssey"},
-      {"THEMIS_IR", "odyssey"},
-      {"THEMIS_VIS", "odyssey"},
-      {"LISM_MI-VIS1", "kaguya"},
-      {"LISM_MI-VIS2", "kaguya"},
-      {"LISM_MI-VIS3", "kaguya"},
-      {"LISM_MI-VIS4", "kaguya"},
-      {"LISM_MI-VIS5", "kaguya"},
-      {"LISM_MI-NIR1", "kaguya"},
-      {"LISM_MI-NIR2", "kaguya"},
-      {"LISM_MI-NIR3", "kaguya"},
-      {"LISM_MI-NIR4", "kaguya"},
-      {"LISM_TC1_WDF", "kaguya"},
-      {"LISM_TC1_WTF", "kaguya"},
-      {"LISM_TC1_SDF", "kaguya"},
-      {"LISM_TC1_STF", "kaguya"},
-      {"LISM_TC1_WDN", "kaguya"},
-      {"LISM_TC1_WTN", "kaguya"},
-      {"LISM_TC1_SDN", "kaguya"},
-      {"LISM_TC1_STN", "kaguya"},
-      {"LISM_TC1_WDH", "kaguya"},
-      {"LISM_TC1_WTH", "kaguya"},
-      {"LISM_TC1_SDH", "kaguya"},
-      {"LISM_TC1_STH", "kaguya"},
-      {"LISM_TC1_SSH", "kaguya"},
-      {"SELENE", "kaguya"},
-      {"KAGUYA", "kaguya"},
-      {"SELENE MAIN ORBITER", "kaguya"},
-      {"LO1_HIGH_RESOLUTION_CAMERA", "lo"},
-      {"LO2_HIGH_RESOLUTION_CAMERA", "lo"},
-      {"LO3_HIGH_RESOLUTION_CAMERA", "lo"},
-      {"LO4_HIGH_RESOLUTION_CAMERA", "lo"},
-      {"LO5_HIGH_RESOLUTION_CAMERA", "lo"},
-      {"LO3_MED_RESOLUTION_CAMERA", "lo"},
-      {"NEPTUNE", "voyager1"}, 
-      {"SATURN", "voyager1"},
-      {"TGO_CASSIS", "cassis"},
-      {"TGO_CASSIS_CRU", "cassis"},
-      {"VIKING ORBITER 1", "viking1"},
-      {"VIKING_ORBITER_1", "viking1"},
-      {"VIKING ORBITER 2", "viking2"},
-      {"VIKING_ORBITER_2", "viking2"},
-      {"VO2_VISB", "viking2"},
-      {"VO2_VISA", "viking2"},
-      {"VO1_VISA", "viking1"},
-      {"VO1_VISB", "viking1"},
-      {"VG1_ISSNA", "voyager1"},
-      {"VG1_ISSWA", "voyager1"},
-      {"VG2_ISSNA", "voyager2"},
-      {"VG2_ISSWA", "voyager2"},
-      {"ULTRAVIOLET/VISIBLE CAMERA", "uvvis"},
-      {"Near Infrared Camera", "nir"},
-      {"High Resolution Camera", "clementine1"},
-      {"Long Wave Infrared Camera", "clementine1"},
-      {"Visual and Infrared Spectrometer", "vir"},
-      {"CLEM_HIRES", "clementine1"},
-      {"CLEM_UVVIS_A", "uvvis"},
-      {"CLEM_LWIR", "clementine1"},
-      {"CLEM_NIR", "nir"},
-      {"CH2", "chandrayaan2"},
-      {"CH-2", "chandrayaan2"},
-      {"CH2_TMC_NADIR", "tmc2"},
-      {"CH2_OHRC", "ohrc"},
-      {"ROS_VIRTIS-M_IR", "virtis"},
-      {"MSL_MASTCAM_LEFT", "msl"}
-    };
     
     /**
      * @brief Translates a given name using the aliasMap and checks if the name is in the frameList.
@@ -172,23 +45,21 @@ namespace SpiceQL {
      * @return The translated name or an empty string if not found.
      */
     std::string getSpiceqlName(const std::string& name) {
-        // Check if name is in aliasMap
-        if (aliasMap.contains(name)) {
-            return aliasMap[name].get<std::string>();
-        }
-        // Check if name is in frameList
-        for (const auto& frame : frameList()) {
-            if (frame == name) {
-                return name;
+        try {
+            return get_mission(name);
+        } catch (invalid_argument e) {
+            SPDLOG_INFO("Unable to get SpiceQL name from aliases: {}", e.what());
+
+            // Check if name is in frameList
+            for (const auto& frame : frameList()) {
+                if (frame == name) {
+                    return name;
+                }
             }
         }
+
         // Not found
         return "";
-    }
-
-
-    void addAliasKey(const std::string& key, const std::string& value) {
-        aliasMap[key] = value;
     }
 
     

--- a/SpiceQL/src/utils.cpp
+++ b/SpiceQL/src/utils.cpp
@@ -1290,4 +1290,29 @@ namespace SpiceQL {
 
     return kernels;
   }
+
+  string getAliasMapJsonFile() {
+    // If running tests or debugging locally
+    char* condaPrefix = std::getenv("CONDA_PREFIX");
+    SPDLOG_TRACE("CONDA_PREFIX: {}", string(condaPrefix));
+    string aliasMapFilename = "aliasMap.json";
+
+    fs::path debugPath = fs::absolute(_SOURCE_PREFIX) / "SpiceQL" / aliasMapFilename;
+    fs::path installPath = fs::absolute(condaPrefix) / "etc" / "SpiceQL" / aliasMapFilename;
+
+    // Use installPath unless $SPICEQL_DEV_ALIAS is set
+    fs::path aliasMapPath;
+    if (std::getenv("SPICEQL_DEV_ALIAS") && toLower(string(std::getenv("SPICEQL_DEV_ALIAS"))) == "true") {
+      aliasMapPath = debugPath; 
+    } else {
+      aliasMapPath = installPath;
+    }
+
+    if (!fs::exists(aliasMapPath)) {
+      throw runtime_error("Alias map JSON file [" + aliasMapPath.string() + "] not found.");
+    }
+    SPDLOG_TRACE("SpiceQL alias map path: {}", aliasMapPath.string()); 
+
+    return aliasMapPath; 
+  }
 }

--- a/SpiceQL/tests/AliasMapTests.cpp
+++ b/SpiceQL/tests/AliasMapTests.cpp
@@ -1,0 +1,42 @@
+#include <gtest/gtest.h>
+#include "Fixtures.h"
+#include "alias_map.h"
+
+using namespace SpiceQL;
+
+TEST_F(AliasMapTest, DefaultLoad) {
+	// Test the default load from source tree
+	load_aliases(defaultAliasMapFile.string());
+	EXPECT_EQ(get_mission("LRO_LROCNACL"), "lroc");
+}
+
+TEST_F(AliasMapTest, LoadFromSpecificPath) {
+	// Verify test file exists
+	ASSERT_TRUE(fs::exists(testAliasMapFile)) 
+			<< "Test data file not found at: " << testAliasMapFile;
+	EXPECT_NO_THROW(load_aliases(testAliasMapFile.string()));
+	EXPECT_EQ(get_mission("Fake"), "test_mission");
+	EXPECT_THROW(get_mission("MRO"), std::invalid_argument);
+	EXPECT_EQ(get_aliases().size(), 2);
+}
+
+TEST_F(AliasMapTest, InvalidAlias) {
+	// Test error handling for missing alias
+	load_aliases(testAliasMapFile.string());
+	EXPECT_THROW(get_mission("bad_alias"), std::invalid_argument);
+}
+
+TEST_F(AliasMapTest, EnsureInit) {
+	// Get mission without loading first will load default automatically
+	EXPECT_EQ(get_mission("CH2_OHRC"), "ohrc");
+}
+
+TEST_F(AliasMapTest, PathParamOverridesEnvironment) {
+	setenv("SPICEQL_DEV_ALIAS", "false", 1);
+	EXPECT_EQ(get_mission("CH2_TMC_NADIR"), "tmc2");
+
+	// load test alias map
+	EXPECT_NO_THROW(load_aliases(testAliasMapFile.string()));
+	EXPECT_THROW((get_mission("CH2_TMC_NADIR"), "tmc2"), std::invalid_argument);
+}
+

--- a/SpiceQL/tests/AliasMapTests.cpp
+++ b/SpiceQL/tests/AliasMapTests.cpp
@@ -1,13 +1,16 @@
 #include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+
 #include "Fixtures.h"
 #include "alias_map.h"
 
 using namespace SpiceQL;
+using json = nlohmann::json;
 
 TEST_F(AliasMapTest, DefaultLoad) {
 	// Test the default load from source tree
 	load_aliases(defaultAliasMapFile.string());
-	EXPECT_EQ(get_mission("LRO_LROCNACL"), "lroc");
+	EXPECT_EQ(aliasMap.getSpiceqlName("LRO_LROCNACL"), "lroc");
 }
 
 TEST_F(AliasMapTest, LoadFromSpecificPath) {
@@ -15,29 +18,51 @@ TEST_F(AliasMapTest, LoadFromSpecificPath) {
 	ASSERT_TRUE(fs::exists(testAliasMapFile)) 
 			<< "Test data file not found at: " << testAliasMapFile;
 	EXPECT_NO_THROW(load_aliases(testAliasMapFile.string()));
-	EXPECT_EQ(get_mission("Fake"), "test_mission");
-	EXPECT_THROW(get_mission("MRO"), std::invalid_argument);
-	EXPECT_EQ(get_aliases().size(), 2);
+	EXPECT_EQ(aliasMap.getSpiceqlName("Fake"), "test_mission");
+	EXPECT_EQ(aliasMap.getSpiceqlName("MRO"), "");
+	EXPECT_EQ(aliasMap.getAliasMap().size(), 1);
 }
 
 TEST_F(AliasMapTest, InvalidAlias) {
 	// Test error handling for missing alias
 	load_aliases(testAliasMapFile.string());
-	EXPECT_THROW(get_mission("bad_alias"), std::invalid_argument);
+	EXPECT_EQ(aliasMap.getSpiceqlName("bad_alias"), "");
 }
 
 TEST_F(AliasMapTest, EnsureInit) {
 	// Get mission without explicit loading, will load default automatically
 	setenv("SPICEQL_DEV_ALIAS", "true", 1);
-	EXPECT_EQ(get_mission("CH2_OHRC"), "ohrc");
+	EXPECT_EQ(aliasMap.getSpiceqlName("CH2_OHRC"), "ohrc");
 }
 
 TEST_F(AliasMapTest, PathParamOverridesEnvironment) {
 	setenv("SPICEQL_DEV_ALIAS", "true", 1);
-	EXPECT_EQ(get_mission("CH2_TMC_NADIR"), "tmc2");
+	EXPECT_EQ(aliasMap.getSpiceqlName("CH2_TMC_NADIR"), "tmc2");
 
 	// load test alias map
 	EXPECT_NO_THROW(load_aliases(testAliasMapFile.string()));
-	EXPECT_THROW(get_mission("CH2_TMC_NADIR"), std::invalid_argument);
+	EXPECT_EQ(aliasMap.getSpiceqlName("CH2_TMC_NADIR"), "");
+}
+
+TEST_F(AliasMapTest, SetAliases) {
+	// Test setting aliases
+	json newAliasMap = { 
+    {"test1", {"alias1", "alias2"}},
+		{"test2", {"alias3"}} 
+	};
+	aliasMap.setAliasMap(newAliasMap);
+
+	json updatedAliasMap = aliasMap.getAliasMap();
+	EXPECT_EQ(updatedAliasMap.size(), 2);
+	EXPECT_EQ(updatedAliasMap["test1"][1], "ALIAS1");
+}
+
+TEST_F(AliasMapTest, GetAliases) {
+	// Verify dev alias map is valid
+	setenv("SPICEQL_DEV_ALIAS", "true", 1);
+	json aliasMapJson = aliasMap.getAliasMap();
+	
+	EXPECT_FALSE(aliasMapJson.empty());
+	EXPECT_GT(aliasMapJson.size(), 46); //currently 47 db keys
 }
 

--- a/SpiceQL/tests/AliasMapTests.cpp
+++ b/SpiceQL/tests/AliasMapTests.cpp
@@ -27,16 +27,17 @@ TEST_F(AliasMapTest, InvalidAlias) {
 }
 
 TEST_F(AliasMapTest, EnsureInit) {
-	// Get mission without loading first will load default automatically
+	// Get mission without explicit loading, will load default automatically
+	setenv("SPICEQL_DEV_ALIAS", "true", 1);
 	EXPECT_EQ(get_mission("CH2_OHRC"), "ohrc");
 }
 
 TEST_F(AliasMapTest, PathParamOverridesEnvironment) {
-	setenv("SPICEQL_DEV_ALIAS", "false", 1);
+	setenv("SPICEQL_DEV_ALIAS", "true", 1);
 	EXPECT_EQ(get_mission("CH2_TMC_NADIR"), "tmc2");
 
 	// load test alias map
 	EXPECT_NO_THROW(load_aliases(testAliasMapFile.string()));
-	EXPECT_THROW((get_mission("CH2_TMC_NADIR"), "tmc2"), std::invalid_argument);
+	EXPECT_THROW(get_mission("CH2_TMC_NADIR"), std::invalid_argument);
 }
 

--- a/SpiceQL/tests/CMakeLists.txt
+++ b/SpiceQL/tests/CMakeLists.txt
@@ -20,7 +20,8 @@ set (SPICEQL_TEST_SOURCE    ${SPICEQL_TEST_DIRECTORY}/TestUtilities.cpp
                             ${SPICEQL_TEST_DIRECTORY}/KernelTests.cpp
                             ${SPICEQL_TEST_DIRECTORY}/MemoTests.cpp
                             ${SPICEQL_TEST_DIRECTORY}/InventoryTests.cpp 
-                            ${SPICEQL_TEST_DIRECTORY}/FunctionalTestsConfig.cpp)
+                            ${SPICEQL_TEST_DIRECTORY}/FunctionalTestsConfig.cpp
+                            ${SPICEQL_TEST_DIRECTORY}/AliasMapTests.cpp)
 
 # setup test executable
 add_executable(runSpiceQLTests TestMain.cpp ${SPICEQL_TEST_SOURCE})

--- a/SpiceQL/tests/Fixtures.cpp
+++ b/SpiceQL/tests/Fixtures.cpp
@@ -397,3 +397,14 @@ void TestConfig::SetUp() {
 void TestConfig::TearDown() {
 
 }
+
+void AliasMapTest::SetUp() {
+  TempTestingFiles::SetUp();
+  root = getenv("SPICEROOT");
+
+  // default aliasMap.json in repo
+  defaultAliasMapFile = fs::path(_SOURCE_PREFIX) / "SpiceQL" / "aliasMap.json";
+
+  // test aliasMap JSON file
+  testAliasMapFile = fs::path("data") / "aliasMap.test.json";
+}

--- a/SpiceQL/tests/Fixtures.h
+++ b/SpiceQL/tests/Fixtures.h
@@ -6,6 +6,7 @@
 #include <ghc/fs_std.hpp>
 
 #include "spice_types.h"
+#include "alias_map.h"
 
 using namespace std;
 using namespace SpiceQL;
@@ -127,6 +128,7 @@ class EnvVar : public ::testing::Test {
 class AliasMapTest : public TempTestingFiles {
  protected:
   void SetUp() override;
+  AliasMap& aliasMap = AliasMap::instance();
   fs::path defaultAliasMapFile;
   fs::path testAliasMapFile;
   fs::path root;

--- a/SpiceQL/tests/Fixtures.h
+++ b/SpiceQL/tests/Fixtures.h
@@ -123,3 +123,11 @@ class EnvVar : public ::testing::Test {
   struct SavedVar { string value; bool hadValue; };
   std::unordered_map<string, SavedVar> saved_;
 };
+
+class AliasMapTest : public TempTestingFiles {
+ protected:
+  void SetUp() override;
+  fs::path defaultAliasMapFile;
+  fs::path testAliasMapFile;
+  fs::path root;
+};

--- a/SpiceQL/tests/data/aliasMap.test.json
+++ b/SpiceQL/tests/data/aliasMap.test.json
@@ -1,0 +1,6 @@
+{
+    "test_mission": [
+        "asd",
+        "FAKE"
+    ]
+}

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -19,7 +19,8 @@ set(PYSPICEQL_SOURCES pyspiceql.i
                       query.i
                       spice_types.i
                       utils.i
-                      api.i)
+                      api.i
+                      alias_map.i)
 set_source_files_properties(${PYSPICEQL_SOURCES} PROPERTIES CPLUSPLUS ON)
 swig_add_library(pyspiceql
                  LANGUAGE python

--- a/bindings/python/alias_map.i
+++ b/bindings/python/alias_map.i
@@ -1,0 +1,8 @@
+%module(package="pyspiceql") alias_map
+
+%{
+  #include "alias_map.h"
+%}
+
+
+%include "alias_map.h"

--- a/bindings/python/pyspiceql.i
+++ b/bindings/python/pyspiceql.i
@@ -267,3 +267,4 @@ namespace std {
 %include "memoized_functions.i"
 %include "inventory.i"
 %include "api.i"
+%include "alias_map.i"


### PR DESCRIPTION
Refactors the `aliasMap` variable that was hardcoded JSON into an external file that can be dynamically loaded and `aliasMap` related implementations.

~~*Note: Function `addAliasKey()` is removed so this may be API breaking.~~
**Not** API breaking: `getSpiceqlName()`, `addAliasKey()`, `getAliasMap()`, `setAliasMap()` still functioning as expected. The logic for these functions were moved to alias_map.cpp and updated to be inline with the new AliasMap implementation.

Introduces one new function:
- `load_aliases(string path="")` - load aliases with option to give a custom JSON file path 

SpiceQL installation will now include the aliasMap.json in SpiceQL/ to be copied to the `$CONDA_PREFIX/etc/SpiceQL` folder. The aliasMap.json in the conda env is the default file that will be loaded automatically when calling `pyspiceql.load_aliases()` or if `getSpiceqlName()`/`getAliasMap()` are called without explicitly loading an alias map first. 

A new environment variable `SPICEQL_DEV_ALIAS` can be set to `true` which will default to the aliasMap.json file in the source repo.

Also able to set a `path` to a custom JSON file of aliases in `load_aliases(path="path/to/aliasMap.custom.json")`.

Any changes made to the JSON file in use can be reflected by calling `load_aliases()` (with `path` if using custom file).

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

