### PR TITLE
added LSK default load to UTC conversions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ release.
 -->
 ### unreleased
 
+### Added 
+- Added feature to UTC conversion functions to load the installed LSK if no kernels are provided. [#126](https://github.com/DOI-USGS/SpiceQL/pull/126#pullrequestreview-4405351255)
+
 ### Fixed
 - Fixed LRO smithed kernels for north and south pole database by moving them from lroc to moc [#124](https://github.com/DOI-USGS/SpiceQL/pull/124)
 - Removed extraneous LROC_NPOLE kernels from isisKernelList.txt [#125](https://github.com/DOI-USGS/SpiceQL/pull/125)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,7 @@ if(SPICEQL_BUILD_LIB)
                            ${CMAKE_CURRENT_SOURCE_DIR}/SpiceQL/db/voyager2.json
                            )
 
-  set(SPICEQL_KERNELS ${CMAKE_CURRENT_SOURCE_DIR}/SpiceQL/db/kernels/naif0011.tls)
+  set(SPICEQL_KERNELS ${CMAKE_CURRENT_SOURCE_DIR}/SpiceQL/db/kernels/naif0012.tls)
 
   configure_file (${CMAKE_CURRENT_SOURCE_DIR}/SpiceQL/include/version.h.in ${CMAKE_CURRENT_SOURCE_DIR}/SpiceQL/include/version.h @ONLY)
   add_library(SpiceQL SHARED ${SPICEQL_SRC_FILES})

--- a/SpiceQL/db/kernels/naif0012.tls
+++ b/SpiceQL/db/kernels/naif0012.tls
@@ -7,6 +7,9 @@ LEAPSECONDS KERNEL FILE
 Modifications:
 --------------
 
+2016, Jul. 14   NJB  Modified file to account for the leapsecond that
+                     will occur on December 31, 2016.
+
 2015, Jan. 5    NJB  Modified file to account for the leapsecond that
                      will occur on June 30, 2015.
 
@@ -141,7 +144,8 @@ DELTET/DELTA_AT        = ( 10,   @1972-JAN-1
                            33,   @2006-JAN-1
                            34,   @2009-JAN-1
                            35,   @2012-JUL-1
-                           36,   @2015-JUL-1 )
+                           36,   @2015-JUL-1 
+                           37,   @2017-JAN-1 )
 
 \begintext
 

--- a/SpiceQL/include/utils.h
+++ b/SpiceQL/include/utils.h
@@ -23,6 +23,8 @@
  */
 namespace SpiceQL {
 
+  /** @brief Load the local LSK file that comes installed with SpiceQL */
+  std::string getDefaultLsk();
 
   /**
    * @brief generate a random string

--- a/SpiceQL/src/api.cpp
+++ b/SpiceQL/src/api.cpp
@@ -668,13 +668,7 @@ namespace SpiceQL {
         // if we're not searching for kernels and not using the web, we still need to load an lsk to do the conversion
         if(useWeb == false && searchKernels == false && kernelList.empty()) {
             SPDLOG_TRACE("No kernels provided, loading default LSK");
-            fs::path configDir = getConfigDirectory();
-            fs::path lskPath = configDir / "kernels" / "naif0012.tls";
-            if (fs::exists(lskPath)) {
-                lsks["lsk"] = json::array({lskPath.string()});
-            } else {
-                throw runtime_error(fmt::format("No LSK found at default path [{}]. Please either place an LSK there, or set searchKernels to true or provide a kernelList with an LSK.", lskPath.string()));
-            }
+            lsks["lsk"] = json::array({getDefaultLsk()});
         }
         
         KernelSet lsk(lsks);
@@ -721,13 +715,7 @@ namespace SpiceQL {
         // if we're not searching for kernels and not using the web, we still need to load an lsk to do the conversion
         if(useWeb == false && searchKernels == false && kernelList.empty()) {
             SPDLOG_TRACE("No kernels provided, loading default LSK");
-            fs::path configDir = getConfigDirectory();
-            fs::path lskPath = configDir / "kernels" / "naif0012.tls";
-            if (fs::exists(lskPath)) {
-                lsks["lsk"] = json::array({lskPath.string()});
-            } else {
-                throw runtime_error(fmt::format("No LSK found at default path [{}]. Please either place an LSK there, or set searchKernels to true or provide a kernelList with an LSK.", lskPath.string()));
-            }
+            lsks["lsk"] = json::array({getDefaultLsk()});
         }
 
         KernelSet lsk(lsks);

--- a/SpiceQL/src/api.cpp
+++ b/SpiceQL/src/api.cpp
@@ -653,15 +653,28 @@ namespace SpiceQL {
         }
 
         json lsks = {};
-
+        
         // get lsk kernel
         if (searchKernels) {
             lsks = Inventory::search_for_kernelset("base", {"lsk"}, default_StartTime, default_StopTime, default_KernelQualities, default_KernelQualities, fullKernelPath, limitCk, limitSpk);
         }
+        
         if (!kernelList.empty()) {
             json regexk = Inventory::search_for_kernelset_from_regex(kernelList, fullKernelPath);
             // merge them into the ephem kernels overwriting anything found in the query
             merge_json(lsks, regexk);
+        }
+        
+        // if we're not searching for kernels and not using the web, we still need to load an lsk to do the conversion
+        if(useWeb == false && searchKernels == false && kernelList.empty()) {
+            SPDLOG_TRACE("No kernels provided, loading default LSK");
+            fs::path configDir = getConfigDirectory();
+            fs::path lskPath = configDir / "kernels" / "naif0012.tls";
+            if (fs::exists(lskPath)) {
+                lsks["lsk"] = json::array({lskPath.string()});
+            } else {
+                throw runtime_error(fmt::format("No LSK found at default path [{}]. Please either place an LSK there, or set searchKernels to true or provide a kernelList with an LSK.", lskPath.string()));
+            }
         }
         
         KernelSet lsk(lsks);
@@ -694,7 +707,7 @@ namespace SpiceQL {
         }   
        
         json lsks = {};
-
+        
         // get lsk kernel
         if (searchKernels) {
             lsks = Inventory::search_for_kernelset("base", {"lsk"}, default_StartTime, default_StopTime, default_KernelQualities, default_KernelQualities, fullKernelPath, limitCk, limitSpk);
@@ -703,6 +716,18 @@ namespace SpiceQL {
             json regexk = Inventory::search_for_kernelset_from_regex(kernelList, fullKernelPath);
             // merge them into the ephem kernels overwriting anything found in the query
             merge_json(lsks, regexk);
+        }
+
+        // if we're not searching for kernels and not using the web, we still need to load an lsk to do the conversion
+        if(useWeb == false && searchKernels == false && kernelList.empty()) {
+            SPDLOG_TRACE("No kernels provided, loading default LSK");
+            fs::path configDir = getConfigDirectory();
+            fs::path lskPath = configDir / "kernels" / "naif0012.tls";
+            if (fs::exists(lskPath)) {
+                lsks["lsk"] = json::array({lskPath.string()});
+            } else {
+                throw runtime_error(fmt::format("No LSK found at default path [{}]. Please either place an LSK there, or set searchKernels to true or provide a kernelList with an LSK.", lskPath.string()));
+            }
         }
 
         KernelSet lsk(lsks);

--- a/SpiceQL/src/utils.cpp
+++ b/SpiceQL/src/utils.cpp
@@ -68,6 +68,17 @@ template <> struct fmt::formatter<fs::path> {
 
 
 namespace SpiceQL {
+  
+  string getDefaultLsk() {
+      fs::path configDir = getConfigDirectory();
+      fs::path lskPath = configDir / "kernels" / "naif0012.tls";
+      if (fs::exists(lskPath)) {
+          return lskPath.string();
+      } else {
+          throw runtime_error(fmt::format("No LSK found at default path [{}]. Please either place an LSK there, or set searchKernels to true or provide a kernelList with an LSK.", lskPath.string()));
+      }
+  }
+
 
   string gen_random(const int len) {
       size_t seed = 0;

--- a/SpiceQL/tests/KernelTests.cpp
+++ b/SpiceQL/tests/KernelTests.cpp
@@ -135,6 +135,17 @@ TEST_F(LroKernelSet, UnitTestUtcToEt) {
 }
 
 
+TEST_F(LroKernelSet, TestUtcToEtNoSearch) {
+  auto [et, kernels] = utcToEt("2016-11-26 22:32:14.582000", false, false);
+  EXPECT_DOUBLE_EQ(et, 533471602.76499087);
+}
+
+
+TEST_F(LroKernelSet, TestEtToUTCNoSearch) {
+  auto [utc, kernels] = etToUtc(533471602.76499087, "ISOC", 6, false, false);
+  EXPECT_STREQ(utc.c_str(), "2016-11-26T22:32:14.582000");
+}
+
 TEST_F(LroKernelSet, UnitTestGetFrameInfo) {
 
   nlohmann::json translationKernels;


### PR DESCRIPTION
Update UTCtoEt and EtToUtc to load the locally installed LSK that ships with SpiceQL. 

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [ ] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

