### PR TITLE
Chandrayaan2 OHRC db fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ release.
 ### Fixed
 - Fixed LRO smithed kernels for north and south pole database by moving them from lroc to moc [#124](https://github.com/DOI-USGS/SpiceQL/pull/124)
 - Removed extraneous LROC_NPOLE kernels from isisKernelList.txt [#125](https://github.com/DOI-USGS/SpiceQL/pull/125)
+- Fixed Chandrayaan2 OHRC IAK db regex [#109](https://github.com/DOI-USGS/SpiceQL/issues/109)
 
 ### 1.3.0
 

--- a/SpiceQL/db/chandrayaan2.json
+++ b/SpiceQL/db/chandrayaan2.json
@@ -19,7 +19,7 @@
     },
     "ohrc" : { 
         "iak" : { 
-            "kernels" : ["mrffrAddendum[0-9]{3}.ti$"]
+            "kernels" : ["^ohrcAddendum[0-9]{3}.ti$"]
         },
         "ik" : { 
             "kernels" : ["^ch2_ohr_v[0-9]{2}.ti$"]

--- a/SpiceQL/tests/QueryTests.cpp
+++ b/SpiceQL/tests/QueryTests.cpp
@@ -237,6 +237,75 @@ TEST_F(IsisDataDirectory, FunctionalTestsLroKernelList) {
 
 TEST_F(IsisDataDirectory, FunctionalTestsCH2KernelList) { 
   compareKernelSets("chandrayaan2", {});
+
+  nlohmann::json conf = getMissionConfig("chandrayaan2");
+  nlohmann::json res = listMissionKernels(tempDir, conf);
+  SPDLOG_DEBUG("Kernel Results: {}", res.dump(4));
+  // check a kernel from each regex exists in their quality groups
+  vector<string> kernelToCheck =  SpiceQL::getKernelsAsVector(res.at("chandrayaan2").at("spk").at("reconstructed").at("kernels"));
+  vector<string> expected = {
+    tempDir/"chandrayaan2"/"kernels"/ "spk" / "ch2_orb_31Mar2020_02May2020_v1.bsp",
+    tempDir/"chandrayaan2"/"kernels"/ "spk" / "ch2_eph_30Sep2025_02Nov2025_v1.bsp"};
+  SPDLOG_DEBUG("Checking TMC2 SPKs");
+  for (auto &e : expected) {
+    auto it = find(kernelToCheck.begin(), kernelToCheck.end(), e);
+    if (it == kernelToCheck.end()) {
+      throw runtime_error(e+" was not found in the kernel results");
+    }
+  }
+
+  kernelToCheck =  SpiceQL::getKernelsAsVector(res.at("chandrayaan2").at("ck").at("reconstructed").at("kernels"));
+  expected = {
+    tempDir/"chandrayaan2"/"kernels"/ "ck" / "ch2_att_01Sep2019_02Oct2019_v1.bc",
+    tempDir/"chandrayaan2"/"kernels"/ "ck" / "ch2_att_27Mar2021_04May2021_v1.bc",
+    tempDir/"chandrayaan2"/"kernels"/ "ck" / "ch2_att_29Nov2020_04Jan2021_v1.bc"};
+  SPDLOG_DEBUG("Checking OHRC CKs");
+  for (auto &e : expected) { 
+    auto it = find(kernelToCheck.begin(), kernelToCheck.end(), e);
+    if (it == kernelToCheck.end()) {
+      throw runtime_error(e+" was not found in the kernel results");
+    }
+  }
+
+  kernelToCheck =  SpiceQL::getKernelsAsVector(res.at("tmc2").at("iak").at("kernels"));
+  expected = {tempDir/"chandrayaan2"/"kernels"/ "iak" / "tmc2Addendum001.ti"};
+  SPDLOG_DEBUG("Checking TMC2 IAKs");
+  for (auto &e : expected) { 
+    auto it = find(kernelToCheck.begin(), kernelToCheck.end(), e);
+    if (it == kernelToCheck.end()) {
+      throw runtime_error(e+" was not found in the kernel results");
+    }
+  }
+
+  kernelToCheck =  SpiceQL::getKernelsAsVector(res.at("ohrc").at("iak").at("kernels"));
+  expected = {tempDir/"chandrayaan2"/"kernels"/ "iak" / "ohrcAddendum001.ti"};
+  SPDLOG_DEBUG("Checking OHRC IAKs");
+  for (auto &e : expected) { 
+    auto it = find(kernelToCheck.begin(), kernelToCheck.end(), e);
+    if (it == kernelToCheck.end()) {
+      throw runtime_error(e+" was not found in the kernel results");
+    }
+  }
+
+  kernelToCheck =  SpiceQL::getKernelsAsVector(res.at("chandrayaan2").at("fk").at("kernels"));
+  expected = {tempDir/"chandrayaan2"/"kernels"/ "fk" / "ch2_v01.tf"};
+  SPDLOG_DEBUG("Checking CH2 FKs");
+  for (auto &e : expected) { 
+    auto it = find(kernelToCheck.begin(), kernelToCheck.end(), e);
+    if (it == kernelToCheck.end()) {
+      throw runtime_error(e+" was not found in the kernel results");
+    }
+  }
+
+  kernelToCheck =  SpiceQL::getKernelsAsVector(res.at("chandrayaan2").at("sclk").at("kernels"));
+  expected = {tempDir/"chandrayaan2"/"kernels"/ "sclk" / "ch2_sclk_v1.tsc"};
+  SPDLOG_DEBUG("Checking CH2 SCLKs");
+  for (auto &e : expected) { 
+    auto it = find(kernelToCheck.begin(), kernelToCheck.end(), e);
+    if (it == kernelToCheck.end()) {
+      throw runtime_error(e+" was not found in the kernel results");
+    }
+  }
 }
 
 TEST_F(IsisDataDirectory, FunctionalTestLroConf) {

--- a/SpiceQL/tests/data/isisKernelList.txt
+++ b/SpiceQL/tests/data/isisKernelList.txt
@@ -15211,5 +15211,6 @@ chandrayaan2/kernels/spk/ch2_eph_30Mar2025_02May2025_v1.bsp
 chandrayaan2/kernels/spk/ch2_eph_30May2025_02Jul2025_v1.bsp
 chandrayaan2/kernels/spk/ch2_eph_30Sep2025_02Nov2025_v1.bsp
 chandrayaan2/kernels/iak/tmc2Addendum001.ti
+chandrayaan2/kernels/iak/ohrcAddendum001.ti
 chandrayaan2/kernels/fk/ch2_v01.tf
 chandrayaan2/kernels/sclk/ch2_sclk_v1.tsc


### PR DESCRIPTION
Addresses the OHRC IAK db issue in this [issue](https://github.com/DOI-USGS/SpiceQL/issues/109). The rest of the CH2 db issues were already addressed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

