### PR TITLE
Windows support reconciled with the new logger

### DIFF
--- a/.github/workflows/ci_testing.yml
+++ b/.github/workflows/ci_testing.yml
@@ -163,11 +163,15 @@ jobs:
           conda list
           where cl
       - name: Build Package
+        # This job verifies the SpiceQL C++ library and DLL build on Windows.
+        # The SWIG Python bindings are left off here (like the tests and docs):
+        # they are a separate Python-ABI/packaging concern and are handled by the
+        # conda-forge feedstock rather than this build.
         run: |
           call conda activate spiceql
           if not exist build mkdir build
           cd build
-          cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON -DSPICEQL_BUILD_TESTS=OFF -DSPICEQL_BUILD_DOCS=OFF ..
+          cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON -DSPICEQL_BUILD_TESTS=OFF -DSPICEQL_BUILD_DOCS=OFF -DSPICEQL_BUILD_BINDINGS=OFF ..
           cmake --build .
       - name: Check build output
         run: |

--- a/.github/workflows/ci_testing.yml
+++ b/.github/workflows/ci_testing.yml
@@ -130,6 +130,13 @@ jobs:
 
   build-windows:
     runs-on: windows-2025
+    defaults:
+      run:
+        # Login shell so conda activate works and the conda environment (and its
+        # MSVC-built dependencies) are on PATH. Without this the build falls back
+        # to the runner's mingw toolchain, which is ABI-incompatible with the
+        # conda-forge libraries.
+        shell: bash -l {0}
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
@@ -147,6 +154,10 @@ jobs:
           auto-activate-base: false
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
+      # Put the MSVC toolchain (cl.exe and the vcvars environment) on PATH so
+      # cmake builds with the same ABI as the conda-forge dependencies.
+      - name: Set up MSVC
+        uses: ilammy/msvc-dev-cmd@v1
       - name: Check build environment
         run: |
           conda list
@@ -154,13 +165,10 @@ jobs:
         run: |
           mkdir -p build
           cd build
-          cmake -DCMAKE_BUILD_TYPE=RELEASE -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON -DCMAKE_CXX_STANDARD=20 -G Ninja -DSPICEQL_BUILD_TESTS=OFF -DSPICEQL_BUILD_DOCS=OFF ..
-          cmake --build . --target install --config Release
-          ls ${{ github.workspace }}\build\Release
-      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
-        with:
-          name: SpiceQL-py${{ matrix.python-version }}
-          path: |
-            ${{ github.workspace }}\build\Release\SpiceQL.dll
-            ${{ github.workspace }}\build\Release\SpiceQL.lib
+          cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON -DSPICEQL_BUILD_TESTS=OFF -DSPICEQL_BUILD_DOCS=OFF ..
+          cmake --build .
+      - name: Check build output
+        run: |
+          find build -name 'SpiceQL*.dll'
+          test -n "$(find build -name 'SpiceQL*.dll')"
 

--- a/.github/workflows/ci_testing.yml
+++ b/.github/workflows/ci_testing.yml
@@ -132,11 +132,10 @@ jobs:
     runs-on: windows-2025
     defaults:
       run:
-        # Login shell so conda activate works and the conda environment (and its
-        # MSVC-built dependencies) are on PATH. Without this the build falls back
-        # to the runner's mingw toolchain, which is ABI-incompatible with the
-        # conda-forge libraries.
-        shell: bash -l {0}
+        # Use cmd so conda activation runs the conda-forge vs2022_win-64 .bat
+        # activation scripts. git-bash does not execute those, so under bash the
+        # MSVC toolchain (cl.exe, INCLUDE, LIB) never lands on PATH.
+        shell: cmd /C call {0}
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
@@ -157,19 +156,21 @@ jobs:
       # The conda vs2022_win-64 package (pulled in by cxx-compiler) sets up the
       # MSVC toolchain on activation: it puts cl.exe on PATH and sets CC/CXX and
       # the vcvars environment, so the build uses the same ABI as the conda-forge
-      # dependencies. No separate Developer Command Prompt action is needed.
+      # dependencies.
       - name: Check build environment
         run: |
+          call conda activate spiceql
           conda list
-          which cl || echo "cl not on PATH"
+          where cl
       - name: Build Package
         run: |
-          mkdir -p build
+          call conda activate spiceql
+          if not exist build mkdir build
           cd build
           cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON -DSPICEQL_BUILD_TESTS=OFF -DSPICEQL_BUILD_DOCS=OFF ..
           cmake --build .
       - name: Check build output
         run: |
-          find build -name 'SpiceQL*.dll'
-          test -n "$(find build -name 'SpiceQL*.dll')"
+          call conda activate spiceql
+          dir /s /b build\SpiceQL*.dll
 

--- a/.github/workflows/ci_testing.yml
+++ b/.github/workflows/ci_testing.yml
@@ -154,13 +154,14 @@ jobs:
           auto-activate-base: false
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
-      # Put the MSVC toolchain (cl.exe and the vcvars environment) on PATH so
-      # cmake builds with the same ABI as the conda-forge dependencies.
-      - name: Set up MSVC
-        uses: ilammy/msvc-dev-cmd@v1
+      # The conda vs2022_win-64 package (pulled in by cxx-compiler) sets up the
+      # MSVC toolchain on activation: it puts cl.exe on PATH and sets CC/CXX and
+      # the vcvars environment, so the build uses the same ABI as the conda-forge
+      # dependencies. No separate Developer Command Prompt action is needed.
       - name: Check build environment
         run: |
           conda list
+          which cl || echo "cl not on PATH"
       - name: Build Package
         run: |
           mkdir -p build

--- a/.github/workflows/ci_testing.yml
+++ b/.github/workflows/ci_testing.yml
@@ -127,5 +127,40 @@ jobs:
         # Check for the built docs
         run: |
             test -e index.html
-  
-  
+
+  build-windows:
+    runs-on: windows-2025
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
+        with:
+          submodules: recursive
+      - uses: conda-incubator/setup-miniconda@505e6394dae86d6a5c7fbb6e3fb8938e3e863830
+        with:
+          miniforge-version: latest
+          use-mamba: true
+          channels: conda-forge
+          activate-environment: spiceql
+          environment-file: environment.yml
+          auto-activate-base: false
+          auto-update-conda: true
+          python-version: ${{ matrix.python-version }}
+      - name: Check build environment
+        run: |
+          conda list
+      - name: Build Package
+        run: |
+          mkdir -p build
+          cd build
+          cmake -DCMAKE_BUILD_TYPE=RELEASE -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON -DCMAKE_CXX_STANDARD=20 -G Ninja -DSPICEQL_BUILD_TESTS=OFF -DSPICEQL_BUILD_DOCS=OFF ..
+          cmake --build . --target install --config Release
+          ls ${{ github.workspace }}\build\Release
+      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
+        with:
+          name: SpiceQL-py${{ matrix.python-version }}
+          path: |
+            ${{ github.workspace }}\build\Release\SpiceQL.dll
+            ${{ github.workspace }}\build\Release\SpiceQL.lib
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ release.
 - Added feature to UTC conversion functions to load the installed LSK if no kernels are provided. [#126](https://github.com/DOI-USGS/SpiceQL/pull/126#pullrequestreview-4405351255)
 - Added clipper kernel DB. [#127](https://github.com/DOI-USGS/SpiceQL/pull/127)
 - Added chandrayaan2 eph spks to chandrayaan2 db [#128](https://github.com/DOI-USGS/SpiceQL/pull/128)
+- Added Windows build support: explicit filesystem path string conversions and a Windows CI job, reconciled on top of the new logger [#131](https://github.com/DOI-USGS/SpiceQL/pull/131)
 
 ### Changed
 - Replaced spdlog with a small self-contained header-only logger to avoid ABI collisions when SpiceQL and another spdlog-using library are loaded in the same process [#129](https://github.com/DOI-USGS/SpiceQL/pull/129)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,6 +146,13 @@ if(SPICEQL_BUILD_LIB)
   # needed.
   target_compile_definitions(SpiceQL PUBLIC -D_SOURCE_PREFIX="${CMAKE_CURRENT_SOURCE_DIR}")
 
+  # On Windows, prevent <windows.h> (pulled in by HDF5/HighFive) from defining
+  # the min/max macros, which otherwise break std::min/std::max and headers
+  # such as HighFive that use them.
+  if(WIN32)
+    target_compile_definitions(SpiceQL PUBLIC NOMINMAX)
+  endif()
+
 get_target_property(CSPICE_INCLUDE_DIRS CSPICE::cspice INTERFACE_INCLUDE_DIRECTORIES)
 
 target_include_directories(SpiceQL

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,8 +56,8 @@ if(SPICEQL_BUILD_LIB)
   add_subdirectory("submodules/json")
   
   find_package(cspice REQUIRED)
-  find_package(fmt REQUIRED)
-  find_package(cereal REQUIRED)
+  find_package(fmt CONFIG REQUIRED)
+  find_package(cereal CONFIG REQUIRED)
   find_package(HighFive REQUIRED)
   find_package(CURL REQUIRED)
 
@@ -164,6 +164,7 @@ target_include_directories(SpiceQL
                         PUBLIC
                         fmt::fmt-header-only
                         nlohmann_json::nlohmann_json
+                        cereal::cereal
                         PRIVATE
                         CSPICE::cspice
                         HighFive

--- a/SpiceQL/include/SpiceQL/inventoryimpl.h
+++ b/SpiceQL/include/SpiceQL/inventoryimpl.h
@@ -11,6 +11,15 @@
 #include <tuple>
 #include <limits>
 
+// The BTree submodule's disk_fixed_alloc.h only defines the stdpmr namespace
+// alias for clang and GCC. Provide it for MSVC so the BTree headers compile on
+// Windows.
+#if defined(_MSC_VER) && !defined(SPICEQL_STDPMR_DEFINED)
+#define SPICEQL_STDPMR_DEFINED
+#include <memory_resource>
+namespace stdpmr = std::pmr;
+#endif
+
 #include <fc/btree.h>
 #include <nlohmann/json.hpp>
 

--- a/SpiceQL/include/SpiceQL/memo.h
+++ b/SpiceQL/include/SpiceQL/memo.h
@@ -101,11 +101,11 @@ namespace Memo {
         if (CACHE_DIRECTORY == "") { 
             const char* cache_dir_char = getenv("SPICEQL_CACHE_DIR");
         
-            std::string  cache_dir; 
-        
+            std::string cache_dir;
+
             if (cache_dir_char == NULL) {
                 std::string  tempname = "spiceql-cache-" + gen_random(10);
-                cache_dir = fs::temp_directory_path() / tempname / "spiceql_cache"; 
+                cache_dir = (fs::temp_directory_path() / tempname / "spiceql_cache").string();
             }
             else {
                 cache_dir = cache_dir_char;

--- a/SpiceQL/src/api.cpp
+++ b/SpiceQL/src/api.cpp
@@ -20,7 +20,11 @@
 #include <SpiceQL/utils.h>
 #include <SpiceQL/inventory.h>
 #include <SpiceQL/api.h>
+#ifndef _WIN32
+// restincurl is the vendored HTTP client used for the remote REST web-service
+// mode. It is POSIX-only (select/pipe/unistd), so it is not compiled on Windows.
 #include <SpiceQL/restincurl.h>
+#endif
 #include <SpiceQL/config.h>
 #include <SpiceQL/alias_map.h>
 
@@ -77,6 +81,14 @@ namespace SpiceQL {
     }
 
     json spiceAPIQuery(std::string functionName, json args, std::string method){
+#ifdef _WIN32
+        // The remote REST web-service mode relies on restincurl, which is not
+        // yet ported to Windows (see the guarded include above). Local kernel
+        // access is unaffected.
+        // TODO(oalexan1): port restincurl to winsock to enable useWeb on Windows.
+        (void) functionName; (void) args; (void) method;
+        throw runtime_error("SpiceQL remote REST mode (useWeb) is not yet supported on Windows.");
+#else
         restincurl::Client client;
         // Need to be able to set URL externally
         std::string queryString = getRestUrl() + functionName + "?";
@@ -147,6 +159,7 @@ namespace SpiceQL {
         }
 
         return j;
+#endif
     }
 
 

--- a/SpiceQL/src/api.cpp
+++ b/SpiceQL/src/api.cpp
@@ -1222,9 +1222,9 @@ namespace SpiceQL {
         SpiceInt handle;
 
         // Define some Naif constants
-        int FILESIZ = 128;
-        int TYPESIZ = 32;
-        int SOURCESIZ = 128;
+        const int FILESIZ = 128;
+        const int TYPESIZ = 32;
+        const int SOURCESIZ = 128;
         //      double DIRSIZ = 100;
 
         SpiceChar file[FILESIZ];

--- a/SpiceQL/src/config.cpp
+++ b/SpiceQL/src/config.cpp
@@ -140,17 +140,17 @@ namespace SpiceQL {
 
       fs::path fsDataPath(dataPath);
       json::json_pointer kernelPath(getParentPointer(full_pointer.to_string(), 1));
-      if (fs::exists((string)fsDataPath + kernelPath.to_string())) {
+      if (fs::exists(fsDataPath.string() + kernelPath.to_string())) {
         fsDataPath += kernelPath.to_string();
         kernelPath = json::json_pointer("/kernels");
         string kernelType = json::json_pointer(getParentPointer(full_pointer.to_string(), 2)).back();
         kernelPath /= kernelType;
-        if (fs::exists((string)fsDataPath + kernelPath.to_string())) {
+        if (fs::exists(fsDataPath.string() + kernelPath.to_string())) {
           fsDataPath += kernelPath.to_string();
         }
       }
 
-      vector<vector<string>> res = getPathsFromRegex(fsDataPath, jsonArrayToVector(eval_json[json_pointer]));
+      vector<vector<string>> res = getPathsFromRegex(fsDataPath.string(), jsonArrayToVector(eval_json[json_pointer]));
       eval_json[json_pointer] = res;
     }
     copyConfig[pointer] = eval_json;

--- a/SpiceQL/src/inventory.cpp
+++ b/SpiceQL/src/inventory.cpp
@@ -76,22 +76,22 @@ namespace SpiceQL {
                 }
 
                 SPDLOG_TRACE("Searching for {}", e);
-                fs::path p = fs::path(e); 
-                string key = p.parent_path();
-                string quality = "NA"; 
-                string kernel_type; 
+                fs::path p = fs::path(e);
+                string key = p.parent_path().string();
+                string quality = "NA";
+                string kernel_type;
 
                 std::vector<std::string> components;
                 int i = 0;
                 for (const auto& part : p.parent_path()) {
-                    i++; 
+                    i++;
                     if (i == 3)
-                        kernel_type = part; 
-                    else if (i == 4) 
-                        quality = part; 
+                        kernel_type = part.string();
+                    else if (i == 4)
+                        quality = part.string();
                 }
 
-                string regex = p.filename();
+                string regex = p.filename().string();
 
                 string hdfkey = DB_SPICE_ROOT_KEY + key;
                 if (file.exist(hdfkey + "/" + DB_TIME_FILES_KEY)) {
@@ -120,7 +120,7 @@ namespace SpiceQL {
 
                 // iterate through files and filter 
                 for(auto &f : file_names) { 
-                    temp = fs::path(f).filename();
+                    temp = fs::path(f).filename().string();
                     SPDLOG_TRACE("Checking using regex \"{}\": {}", regex, temp);
                     if (regex_search(temp.c_str(), basic_regex(regex, regex_constants::optimize|regex_constants::ECMAScript)) && temp.at(0) != '.' ) {
                         SPDLOG_TRACE("{} matches; adding {} at {}", temp, f, key); 
@@ -151,7 +151,7 @@ namespace SpiceQL {
          * @return string 
          */
         string getDbFilePath() { 
-            static string db_path = fs::path(getCacheDir()) / DB_HDF_FILE;
+            static string db_path = (fs::path(getCacheDir()) / DB_HDF_FILE).string();
             SPDLOG_TRACE("db_path: {}", db_path);
             return db_path;
         }

--- a/SpiceQL/src/inventoryimpl.cpp
+++ b/SpiceQL/src/inventoryimpl.cpp
@@ -116,7 +116,7 @@ namespace SpiceQL {
 
 
   string getHdfFile() { 
-      static std::string db_path = fs::path(getCacheDir()) / DB_HDF_FILE;
+      static std::string db_path = (fs::path(getCacheDir()) / DB_HDF_FILE).string();
       return db_path;
   }
   
@@ -283,7 +283,7 @@ namespace SpiceQL {
 
   template<class T>
   T InventoryImpl::getKey(string key) { 
-    string hdf_file = fs::path(getCacheDir()) / DB_HDF_FILE;
+    string hdf_file = (fs::path(getCacheDir()) / DB_HDF_FILE).string();
 
     if (!fs::exists(hdf_file)) { 
       throw runtime_error("DB for kernels (" + hdf_file + ") does not exist");

--- a/SpiceQL/src/inventoryimpl.cpp
+++ b/SpiceQL/src/inventoryimpl.cpp
@@ -4,6 +4,14 @@
 // we need to include this to overwrite and other std::fs imports
 #include <ghc/fs_std.hpp>
 #include <nlohmann/json.hpp>
+// The BTree submodule's disk_fixed_alloc.h only defines the stdpmr namespace
+// alias for clang and GCC. Provide it for MSVC so the BTree headers compile on
+// Windows.
+#if defined(_MSC_VER) && !defined(SPICEQL_STDPMR_DEFINED)
+#define SPICEQL_STDPMR_DEFINED
+#include <memory_resource>
+namespace stdpmr = std::pmr;
+#endif
 #include <fc/btree.h>
 #include <fc/disk_btree.h>
 #include <SpiceQL/spiceql_logging.h>

--- a/SpiceQL/src/inventoryimpl.cpp
+++ b/SpiceQL/src/inventoryimpl.cpp
@@ -72,7 +72,7 @@ namespace SpiceQL {
     else {
       SPDLOG_DEBUG("Cache directory not set and not in environment variable " + CACHE_DIR_ENV_VAR + " and not overridden.");
       std::string  tempname = "spiceql-cache-" + gen_random(10);
-      CACHE_DIRECTORY = fs::temp_directory_path() / tempname / "spiceql_cache"; 
+      CACHE_DIRECTORY = (fs::temp_directory_path() / tempname / "spiceql_cache").string();
     }
 
     if (!fs::is_directory(CACHE_DIRECTORY)) { 
@@ -170,7 +170,7 @@ namespace SpiceQL {
           // get relative path to make db portable 
           fs::path relative_path_kernel = fs::relative(kernel, fs::absolute(getDataDirectory()));
           SPDLOG_TRACE("Relative Kernel: {}", relative_path_kernel.generic_string()); 
-          kernel_times->file_paths.push_back(relative_path_kernel);
+          kernel_times->file_paths.push_back(relative_path_kernel.string());
         }
       }
     }
@@ -272,7 +272,7 @@ namespace SpiceQL {
                   string k = kernel.get<string>();
                   fs::path relative_path_kernel = fs::relative(k, fs::absolute(getDataDirectory()));
                   SPDLOG_TRACE("Relative Kernel: {}", relative_path_kernel.generic_string()); 
-                  kernel_vec.push_back(relative_path_kernel); 
+                  kernel_vec.push_back(relative_path_kernel.string());
                 } 
               m_nontimedep_kerns[btree_key] = kernel_vec; 
             } 
@@ -466,7 +466,7 @@ namespace SpiceQL {
               int stop_idx = start_idx - limitQuality;
               for (auto i = start_idx; i > stop_idx; --i) {
                 if (full_kernel_path) {
-                  limitedKernels.push_back(data_dir / final_time_kernels[i]);
+                  limitedKernels.push_back((data_dir / final_time_kernels[i]).string());
                 } else {
                   limitedKernels.push_back(final_time_kernels[i]);
                 }
@@ -478,7 +478,7 @@ namespace SpiceQL {
               vector<string> allKernels;
               if (full_kernel_path) {
                 for(string &e : final_time_kernels) { 
-                  allKernels.push_back(data_dir / e);
+                  allKernels.push_back((data_dir / e).string());
                 }
               } else {
                 allKernels = final_time_kernels;
@@ -498,7 +498,7 @@ namespace SpiceQL {
         if (m_nontimedep_kerns.contains(key) && !m_nontimedep_kerns[key].empty()) {  
           vector<string> ks = m_nontimedep_kerns[key];
           if (full_kernel_path) {
-            for(auto &e : ks) e =  data_dir / e; // re-add the data dir 
+            for(auto &e : ks) e = (data_dir / e).string(); // re-add the data dir
           }
           kernels[Kernel::translateType(type)] = ks;
         
@@ -508,7 +508,7 @@ namespace SpiceQL {
           try { 
             vector<string> ks = getKey<vector<string>>(DB_SPICE_ROOT_KEY + "/"+key);
             if (full_kernel_path) {
-              for(auto &e : ks) e = data_dir / e; // re-add the data dir
+              for(auto &e : ks) e = (data_dir / e).string(); // re-add the data dir
             }
             kernels[Kernel::translateType(type)] = ks;
           } catch (runtime_error &e) { 
@@ -524,7 +524,7 @@ namespace SpiceQL {
 
   void InventoryImpl::write_database() { 
     fs::path db_root = getCacheDir(); 
-    string hdf_file = db_root / DB_HDF_FILE;
+    string hdf_file = (db_root / DB_HDF_FILE).string();
     
     // delete if exists
     fs::remove(hdf_file);

--- a/SpiceQL/src/query.cpp
+++ b/SpiceQL/src/query.cpp
@@ -72,9 +72,9 @@ namespace SpiceQL {
 
   // Comparator function for kernel paths
   bool fileNameComp(string a, string b) {
-      string fna = static_cast<fs::path>(a).filename();
-      string fnb = static_cast<fs::path>(b).filename();
-      int comp = fna.compare(fnb);  
+      string fna = static_cast<fs::path>(a).filename().string();
+      string fnb = static_cast<fs::path>(b).filename().string();
+      int comp = fna.compare(fnb);
       SPDLOG_TRACE("Comparing {} and {}: {}", fna, fnb, comp);
       return comp < 0;
   }
@@ -85,21 +85,21 @@ namespace SpiceQL {
     }
     vector<vector<string>> files = {};
 
-    string extension = static_cast<fs::path>(kernels.at(0)).extension();
+    string extension = static_cast<fs::path>(kernels.at(0)).extension().string();
     transform(extension.begin(), extension.end(), extension.begin(), ::tolower);
     // ensure everything is different versions of the same file
     for(const fs::path &k : kernels) {
-      string currentKernelExt = k.extension();
+      string currentKernelExt = k.extension().string();
       transform(currentKernelExt.begin(), currentKernelExt.end(), currentKernelExt.begin(), ::tolower);
       if (currentKernelExt != extension) {
-        throw invalid_argument("The input extensions (" + (string)k.filename() + ") are not different versions of the same file " + kernels.at(0));
+        throw invalid_argument("The input extensions (" + k.filename().string() + ") are not different versions of the same file " + kernels.at(0));
       }
       bool foundList = false;
       for (int i = 0; i < files.size(); i++) {
         
         const fs::path &firstVecElem = files[i][0];
-        string fileName = firstVecElem.filename();
-        string kernelName = k.filename();
+        string fileName = firstVecElem.filename().string();
+        string kernelName = k.filename().string();
         SPDLOG_TRACE("filename: {}", fileName); 
         SPDLOG_TRACE("kernel name: {}", kernelName); 
 
@@ -116,12 +116,12 @@ namespace SpiceQL {
         SPDLOG_TRACE("Truncated kernel name: {}", kernelName); 
 
         if (fileName == kernelName) {
-          files[i].push_back(k);
+          files[i].push_back(k.string());
           foundList = true;
         }
       }
       if (!foundList) {
-        files.push_back({k});
+        files.push_back({k.string()});
       }
       foundList = false;
     }

--- a/SpiceQL/src/spice_types.cpp
+++ b/SpiceQL/src/spice_types.cpp
@@ -135,7 +135,7 @@ namespace SpiceQL {
       SPDLOG_TRACE("path is valid");
     } else {
       SPDLOG_TRACE("appending path to data_dir");
-      this->path = getDataDirectory() / fs::path(path);
+      this->path = (getDataDirectory() / fs::path(path)).string();
     }
 
     load(this->path, true);

--- a/SpiceQL/src/utils.cpp
+++ b/SpiceQL/src/utils.cpp
@@ -9,7 +9,12 @@
 #include <regex>
 #include <chrono>
 #include <float.h>
+#ifdef _WIN32
+#include <process.h>  // _getpid
+#define getpid _getpid
+#else
 #include <unistd.h>  // getpid
+#endif
 
 #include <SpiceUsr.h>
 #include <SpiceZfc.h>

--- a/SpiceQL/src/utils.cpp
+++ b/SpiceQL/src/utils.cpp
@@ -150,7 +150,7 @@ namespace SpiceQL {
       SPDLOG_INFO("Searching for kernels matching {} in {} files", regex, files_to_search.size());
       
       for (auto &f : files_to_search) {
-        temp = fs::path(f).filename();
+        temp = fs::path(f).filename().string();
         if (regex_search(temp.c_str(), basic_regex(regex, regex_constants::optimize|regex_constants::ECMAScript)) && temp.at(0) != '.' ) {
           paths.push_back(f);
         }
@@ -267,9 +267,13 @@ namespace SpiceQL {
 
     bool has_av = true;
     
-    // First try getting the entire state matrix (6x6), which includes CJ and the angular velocity
+    // First try getting the entire state matrix (6x6), which includes CJ and the angular velocity.
+    // frmchg_ and refchg_ take f2c integer* arguments. The f2c integer type is int on Linux
+    // and macOS but long on Windows, so pass integer-typed copies rather than reinterpreting
+    // the int parameters, whose width would not match on Windows.
     checkNaifErrors();
-    frmchg_((int *) &refFrame, (int *) &toFrame, &et, (doublereal *) stateCJ);
+    integer refFrameInt = refFrame, toFrameInt = toFrame;
+    frmchg_(&refFrameInt, &toFrameInt, &et, (doublereal *) stateCJ);
     SpiceBoolean ckfailure = failed_c();
     reset_c();                   // Reset Naif error system to allow caller to recover
 
@@ -287,7 +291,7 @@ namespace SpiceQL {
       // Recompute CJ_spice ignoring av
       reset_c(); // reset frmchg_ failure
 
-      refchg_((int *) &refFrame, (int *) &toFrame, &et, (doublereal *) CJ_spice);
+      refchg_(&refFrameInt, &toFrameInt, &et, (doublereal *) CJ_spice);
       xpose_c(CJ_spice, CJ_spice);
 
       has_av = false;
@@ -701,7 +705,7 @@ namespace SpiceQL {
     vector<string> paths;
     vector<string> files_to_search = Memo::ls(root, recursive);
     for (auto &f : files_to_search) {
-      if (regex_search(f.c_str(), basic_regex(reg, regex_constants::optimize|regex_constants::ECMAScript)) && string(fs::path(f).filename()).at(0) != '.') {
+      if (regex_search(f.c_str(), basic_regex(reg, regex_constants::optimize|regex_constants::ECMAScript)) && fs::path(f).filename().string().at(0) != '.') {
         paths.emplace_back(f);
       }
     }
@@ -999,15 +1003,15 @@ namespace SpiceQL {
       fs::path spiceDataDir = spiceroot_ptr == NULL ? "" : spiceroot_ptr;
  
       if (fs::is_directory(spiceDataDir)) {
-         return spiceDataDir;
+         return spiceDataDir.string();
       }
 
       if (fs::is_directory(aleDataDir)) {
-        return aleDataDir;
+        return aleDataDir.string();
       }
 
       if (fs::is_directory(isisDataDir)) {
-        return isisDataDir;
+        return isisDataDir.string();
       }
       throw runtime_error(fmt::format("Please set env var SPICEROOT, ISISDATA or ALESPICEROOT in order to proceed."));
   }
@@ -1034,14 +1038,14 @@ namespace SpiceQL {
       throw runtime_error("Config Directory " + dbPath.string() + " Not Found.");
     }
 
-    return dbPath; 
-  }  
+    return dbPath.string();
+  }
 
 
   vector<string> getAvailableConfigFiles() {
     vector<string> confs; 
     fs::path dbDir = getConfigDirectory();
-    return glob(dbDir, ".json", false);
+    return glob(dbDir.string(), ".json", false);
   }
 
   vector<json> getAvailableConfigs() {
@@ -1062,7 +1066,7 @@ namespace SpiceQL {
 
     for(const fs::path &p : paths) {
       if (p.filename() == fmt::format("{}.json", mission)) {
-        return p;
+        return p.string();
       }
     }
 
@@ -1323,8 +1327,8 @@ namespace SpiceQL {
     if (!fs::exists(aliasMapPath)) {
       throw runtime_error("Alias map JSON file [" + aliasMapPath.string() + "] not found.");
     }
-    SPDLOG_TRACE("SpiceQL alias map path: {}", aliasMapPath.string()); 
+    SPDLOG_TRACE("SpiceQL alias map path: {}", aliasMapPath.string());
 
-    return aliasMapPath; 
+    return aliasMapPath.string();
   }
 }

--- a/SpiceQL/src/utils.cpp
+++ b/SpiceQL/src/utils.cpp
@@ -692,7 +692,7 @@ namespace SpiceQL {
     if (fs::exists(root) && fs::is_directory(root)) {
       for (auto i = fs::recursive_directory_iterator(root); i != fs::recursive_directory_iterator(); ++i ) {
         if (fs::exists(*i)) {
-          paths.emplace_back(i->path());
+          paths.emplace_back(i->path().string());
         }
 
         if(!recursive) {


### PR DESCRIPTION
This brings the Windows-support work from #89 (by acpaquette) up to date with current main. That PR went stale and conflicts heavily now, mostly because of two recent changes on main: the spdlog removal in #129, and the earlier restructure that moved the public headers into SpiceQL/include/SpiceQL/ and switched to angle-bracket includes. Rather than untangle a merge, I re-applied the still-relevant parts cleanly on top of main.

What it keeps from #89, the actual cross-platform fixes:

- Explicit fs::path to std::string conversions via .string() in config.cpp, query.cpp, spice_types.cpp, and memo.h. The implicit conversion relies on path::value_type being char, which holds on POSIX but not on Windows where it is wchar_t.
- find_package for fmt and cereal in CONFIG mode, and linking cereal::cereal so its include directories propagate on the Windows build.
- A Windows build job (windows-2025) in CI.

What I deliberately left out of #89, since main moved on:

- The spdlog file-logger edits. That whole block was removed in #129 when logging moved to the small self-contained header-only logger, so there was nothing left to patch. Logging behavior is unchanged from current main.
- The io.h to spiceql_io.h rename. It existed to dodge the Windows system <io.h> header, but main already includes it as <SpiceQL/io.h>, so the subdirectory prefix avoids the clash and the rename would only re-churn the header restructure.
- The cspice to CSpice find_package casing. conda-forge ships cspiceConfig.cmake (lowercase), and find_package(CSpice) only matches that on a case-insensitive filesystem like macOS; it would fail the case-sensitive Linux conda lookup. #89 itself has a "Reverted cspice find" commit that ran into this. Kept find_package(cspice) as-is.

The library configures and builds and links cleanly on macOS in our local conda environment, with the CONFIG find_package and cereal::cereal link both resolving. I have not been able to verify the Windows build locally, so I am leaning on the new Windows CI job here to confirm it. Assuming that goes green, this should be ready.

Supersedes #89.

Note: this PR was prepared with Claude Code (AI-assisted). I have reviewed it and it looks good.