### PR TITLE
added windows support to utc2et

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ release.
 - Replaced spdlog with a small self-contained header-only logger to avoid ABI collisions when SpiceQL and another spdlog-using library are loaded in the same process [#129](https://github.com/DOI-USGS/SpiceQL/pull/129)
 
 ### Fixed
+- fixed utctoet for windows [#135](https://github.com/DOI-USGS/SpiceQL/pull/135)
 - Fixed LRO smithed kernels for north and south pole database by moving them from lroc to moc [#124](https://github.com/DOI-USGS/SpiceQL/pull/124)
 - Removed extraneous LROC_NPOLE kernels from isisKernelList.txt [#125](https://github.com/DOI-USGS/SpiceQL/pull/125)
 - Fixed Chandrayaan2 OHRC IAK db regex [#109](https://github.com/DOI-USGS/SpiceQL/issues/109)

--- a/submodules/utcet/utcet.h
+++ b/submodules/utcet/utcet.h
@@ -4,6 +4,13 @@
 #include <string>
 #include <vector>
 
+// Windows compatibility
+#ifdef _WIN32
+  #define timegm _mkgmtime
+  #include <iomanip>
+  #include <sstream>
+#endif
+
 // Leap-second table: UTC dates when TAI-UTC incremented.
 // Source: IERS Bulletin C / NAIF naif0012.tls.
 namespace {
@@ -44,6 +51,21 @@ namespace {
     }
     return leap;
   }
+
+#ifdef _WIN32
+  // Windows-compatible strptime replacement for ISO 8601 format
+  char* portable_strptime(const char* s, const char* format, struct tm* tm) {
+    std::istringstream input(s);
+    input.imbue(std::locale("C"));
+    input >> std::get_time(tm, format);
+    if (input.fail()) {
+      return nullptr;
+    }
+    // Return pointer to remaining string
+    return const_cast<char*>(s + input.tellg());
+  }
+  #define strptime portable_strptime
+#endif
 }
 
 double calendarTimeToEphemTime(std::string calendarTime) {

--- a/submodules/utcet/utcet.h
+++ b/submodules/utcet/utcet.h
@@ -135,11 +135,12 @@ std::string ephemTimeToCalendarTime(double ephemTime, std::string format, int pr
                         "{" + std::to_string(required_size) + "}");
   }
 
-  char buffer[utclen];
-  strftime(buffer, 20, "%Y-%m-%dT%H:%M:%S", std::gmtime(&utc_unix));
+  // Use std::vector instead of VLA for Windows/MSVC compatibility
+  std::vector<char> buffer(utclen);
+  strftime(buffer.data(), 20, "%Y-%m-%dT%H:%M:%S", std::gmtime(&utc_unix));
 
   // Add fractional seconds (without 'Z' to match NAIF format)
   std::string precisionStr = ".%0" + std::to_string(prec) + "d";
-  snprintf(buffer + 19, prec + 2, precisionStr.c_str(), (int)frac);
-  return buffer;
+  snprintf(buffer.data() + 19, prec + 2, precisionStr.c_str(), (int)frac);
+  return buffer.data();
 }


### PR DESCRIPTION
Fixes minor issue after merging the windows support

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [ ] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

