### PR TITLE
version bump for 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ release.
 -->
 ### unreleased
 
+## 1.4.1
+
+### Fixed
+- Fixed utcet leap-second extrapolation for dates before 1972 so pre-1972 epochs (e.g. Apollo) match CSPICE, and broadened UTC string parsing to support the calendar formats CSPICE's str2et accepts [#137](https://github.com/DOI-USGS/SpiceQL/pull/137)
+
 ## 1.4.0
 
 ### Added 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(CMakeDependentOption)
 cmake_minimum_required(VERSION 3.10)
-project(SpiceQL VERSION 1.4.0 DESCRIPTION "Spice Query Library")
+project(SpiceQL VERSION 1.4.1 DESCRIPTION "Spice Query Library")
 
 set(PACKAGE_VERSION ${PROJECT_VERSION})
 

--- a/code.json
+++ b/code.json
@@ -591,5 +591,51 @@
       "date": {
         "metadataLastUpdated": "2026-06-09"
       }
+    },
+    {
+      "name": "SpiceQL",
+      "organization": "U.S. Geological Survey",
+      "description": "GitLab repository for library that interacts with NAIF's SPICE kernels",
+      "version": "1.4.1",
+      "status": "Development",
+
+      "permissions": {
+        "usageType": "openSource",
+        "licenses": [
+          {
+            "name": "Public Domain, CC0-1.0",
+            "URL": "https://code.usgs.gov/astrogeology/spiceql/-/raw/main/LICENSE.md"
+          }
+        ]
+      },
+
+      "homepageURL": "https://code.usgs.gov/astrogeology/spiceql/",
+      "downloadURL": "https://code.usgs.gov/astrogeology/spiceql/-/archive/1.4.1/spiceql-1.4.1.zip",
+      "disclaimerURL": "https://code.usgs.gov/astrogeology/spiceql/-/raw/1.4.1/DISCLAIMER.md",
+      "repositoryURL": "https://code.usgs.gov/astrogeology/spiceql.git",
+      "vcs": "git",
+
+      "laborHours": 520,
+
+      "tags": [
+        "Planetary",
+        "Remote Sensing",
+        "Data Processing",
+        "Ephemerides",
+        "Kernels"
+      ],
+
+      "languages": [
+        "C++", "Python"
+      ],
+
+      "contact": {
+        "name": "Kelvin Rodriguez",
+        "email": "krodriguez@usgs.gov"
+      },
+
+      "date": {
+        "metadataLastUpdated": "2026-06-10"
+      }
     }
   ]


### PR DESCRIPTION
## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

