### PR TITLE
Fix empty mission param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ release.
 -->
 ### unreleased
 
+### Fixed
+- Fixed empty mission param bug so getCacheDir() will auto-initialize [#144](https://github.com/DOI-USGS/SpiceQL/pull/144)
+
 ## 1.5.0 - 2026-06-27
 
 ### Added 

--- a/SpiceQL/src/inventoryimpl.cpp
+++ b/SpiceQL/src/inventoryimpl.cpp
@@ -67,61 +67,40 @@ namespace SpiceQL {
 
 
   void setCacheDir(string cache_dir, bool override) {
-    
     const char* cache_dir_char = getenv(CACHE_DIR_ENV_VAR.c_str());
-    if (cache_dir_char == NULL || override) {
-      SPDLOG_DEBUG("Setting cache directory to: {}", cache_dir);
+
+    // Priority order: override > env var > provided cache_dir > auto-generate
+    if (override && cache_dir != "") {
+      SPDLOG_DEBUG("Setting cache directory (override): {}", cache_dir);
       CACHE_DIRECTORY = cache_dir;
     }
     else if (cache_dir_char != NULL) {
       SPDLOG_DEBUG("Cache directory set in environment variable " + CACHE_DIR_ENV_VAR + ": " + cache_dir_char);
       CACHE_DIRECTORY = cache_dir_char;
     }
+    else if (cache_dir != "") {
+      SPDLOG_DEBUG("Setting cache directory to: {}", cache_dir);
+      CACHE_DIRECTORY = cache_dir;
+    }
     else {
       SPDLOG_DEBUG("Cache directory not set and not in environment variable " + CACHE_DIR_ENV_VAR + " and not overridden.");
-      std::string  tempname = "spiceql-cache-" + gen_random(10);
+      std::string tempname = "spiceql-cache-" + gen_random(10);
       CACHE_DIRECTORY = (fs::temp_directory_path() / tempname / "spiceql_cache").string();
     }
 
-    if (!fs::is_directory(CACHE_DIRECTORY)) { 
+    if (!fs::is_directory(CACHE_DIRECTORY)) {
       SPDLOG_DEBUG("{} does not exist, attempting to create the directory", CACHE_DIRECTORY);
-      fs::create_directories(CACHE_DIRECTORY); 
+      fs::create_directories(CACHE_DIRECTORY);
     }
-    
-    SPDLOG_DEBUG("Setting cache directory to: {}", CACHE_DIRECTORY);  
+
+    SPDLOG_DEBUG("Setting cache directory to: {}", CACHE_DIRECTORY);
   }
 
 
-  string getCacheDir() { 
-
-      if (CACHE_DIRECTORY == "") { 
-          const char* cache_dir_char = getenv(CACHE_DIR_ENV_VAR.c_str());
-      
-          std::string  cache_dir; 
-      
-          if (cache_dir_char == NULL && (CACHE_DIRECTORY == "")) {
-            SPDLOG_DEBUG("Cache directory not set and not in environment variable " + CACHE_DIR_ENV_VAR + " and not overridden.");
-            throw runtime_error("Cache directory not set and not in environment variable " + CACHE_DIR_ENV_VAR + " and not overridden.");
-          }
-          else if (CACHE_DIRECTORY != "") {
-            SPDLOG_DEBUG("Cache directory set in CACHE_DIRECTORY: " + CACHE_DIRECTORY);
-            cache_dir = CACHE_DIRECTORY;
-          }
-          else if (cache_dir_char != NULL) {
-            SPDLOG_DEBUG("Cache directory set in environment variable " + CACHE_DIR_ENV_VAR + ": " + cache_dir_char);
-            cache_dir = cache_dir_char;
-          }
-          else {
-            throw runtime_error("Cache directory not set and not in environment variable " + CACHE_DIR_ENV_VAR + " and not overridden.");
-          }
-
-          if (!fs::is_directory(cache_dir)) { 
-              SPDLOG_DEBUG("{} does not exist, attempting to create the directory", cache_dir);
-              fs::create_directories(cache_dir); 
-          }
-      
-          CACHE_DIRECTORY = cache_dir;
-          SPDLOG_DEBUG("Setting cache directory to: {}", CACHE_DIRECTORY);  
+  string getCacheDir() {
+      if (CACHE_DIRECTORY == "") {
+          // Auto-initialize cache directory using setCacheDir logic
+          setCacheDir("");
       } 
       else { 
           SPDLOG_TRACE("Cache Directory Already Set: {}", CACHE_DIRECTORY);  

--- a/SpiceQL/tests/InventoryTests.cpp
+++ b/SpiceQL/tests/InventoryTests.cpp
@@ -166,12 +166,13 @@ TEST_F(TempTestingFiles, TestInventorySetCacheDirOverride) {
 
 TEST(TestInventory, GetCacheDirAutoInitialize) {
   // Test getCacheDir auto-initialization
-  
+
   // Save original state
   const char* original_cache_dir = getenv("SPICEQL_CACHE_DIR");
 
-  // Clear the environment variable and reset internal state
+  // Clear the environment variable and force reset internal cache directory
   unsetenv("SPICEQL_CACHE_DIR");
+  SpiceQL::setCacheDir("", true);  // Reset internal state to trigger auto-init path
 
   // getCacheDir should auto-initialize with a temp directory instead of throwing
   std::string cache_dir;

--- a/SpiceQL/tests/InventoryTests.cpp
+++ b/SpiceQL/tests/InventoryTests.cpp
@@ -154,7 +154,89 @@ TEST_F(TempTestingFiles, TestInventorySetCacheDirOverride) {
   EXPECT_EQ(SpiceQL::Inventory::getDbFilePath(), new_path/"spiceqldb.hdf");
 }
 
-TEST(TestInventory, SetCacheDirFail) { 
+TEST(TestInventory, GetCacheDirAutoInitialize) {
+  // Test getCacheDir auto-initialization
+  
+  // Save original state
+  const char* original_cache_dir = getenv("SPICEQL_CACHE_DIR");
+
+  // Clear the environment variable and reset internal state
   unsetenv("SPICEQL_CACHE_DIR");
-  EXPECT_THROW(SpiceQL::Inventory::getDbFilePath(), runtime_error);
+
+  // getCacheDir should auto-initialize with a temp directory instead of throwing
+  std::string cache_dir;
+  EXPECT_NO_THROW({
+    cache_dir = SpiceQL::getCacheDir();
+  });
+
+  // Verify auto-initialized directory is not empty
+  EXPECT_FALSE(cache_dir.empty());
+
+  // Verify it contains "spiceql-cache" in the path
+  EXPECT_TRUE(cache_dir.find("spiceql-cache") != std::string::npos);
+
+  // Verify the directory was created
+  EXPECT_TRUE(fs::exists(cache_dir));
+  EXPECT_TRUE(fs::is_directory(cache_dir));
+
+  // Verify subsequent calls return the same cached value
+  std::string cache_dir2 = SpiceQL::getCacheDir();
+  EXPECT_EQ(cache_dir, cache_dir2);
+
+  // Restore original environment
+  if (original_cache_dir != nullptr) {
+    setenv("SPICEQL_CACHE_DIR", original_cache_dir, 1);
+  }
+}
+
+TEST(TestInventory, SetCacheDirPriority) {
+  // Test setCacheDir priority order: override > env var > provided value > auto-generate
+
+  // Save original state
+  const char* original_cache_dir = getenv("SPICEQL_CACHE_DIR");
+
+  fs::path env_dir = fs::temp_directory_path() / "spiceql-env-test";
+  fs::path provided_dir = fs::temp_directory_path() / "spiceql-provided-test";
+
+  // Test 1: env var takes precedence over provided value when override=false
+  setenv("SPICEQL_CACHE_DIR", env_dir.string().c_str(), 1);
+  SpiceQL::setCacheDir(provided_dir.string(), false);
+  EXPECT_EQ(SpiceQL::getCacheDir(), env_dir.string());
+
+  // Test 2: override=true forces provided value even with env var set
+  SpiceQL::setCacheDir(provided_dir.string(), true);
+  EXPECT_EQ(SpiceQL::getCacheDir(), provided_dir.string());
+
+  // Restore original environment
+  if (original_cache_dir != nullptr) {
+    setenv("SPICEQL_CACHE_DIR", original_cache_dir, 1);
+  } else {
+    unsetenv("SPICEQL_CACHE_DIR");
+  }
+}
+
+TEST_F(LroKernelSet, InferMissionInitCache) {
+  // Test inferMission triggers cache auto-init
+  // Save original state
+  const char* original_cache_dir = getenv("SPICEQL_CACHE_DIR");
+
+  // Clear environment to force auto-initialization
+  unsetenv("SPICEQL_CACHE_DIR");
+
+  // Empty mission triggers: inferMission() → frameList() → getCacheDir() → auto-init
+  // Auto-initializes with temp directory
+  std::pair<nlohmann::json, nlohmann::json> result;
+  EXPECT_NO_THROW({
+    result = SpiceQL::getTargetFrameInfo(301, "");
+  });
+
+  // Verify cache was auto-initialized
+  std::string cache_dir = SpiceQL::getCacheDir();
+  EXPECT_FALSE(cache_dir.empty());
+  EXPECT_TRUE(fs::exists(cache_dir));
+
+  // Restore original environment
+  if (original_cache_dir != nullptr) {
+    setenv("SPICEQL_CACHE_DIR", original_cache_dir, 1);
+  }
 }


### PR DESCRIPTION
Fixes a bug introduced in PR #140 where `getTargetFrameInfo()` with an empty mission string would throw a runtime error when the cache directory was not explicitly initialized.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

