### PR TITLE
Add etsToSclkTicks endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ release.
 -->
 ### Unreleased
 
+### Added
+- Added `etsToSclkTicks()` API function and updated `writeCk()` to support web-enabled CK generation [#146](https://github.com/DOI-USGS/SpiceQL/pull/146)
+
 ## 1.6.0 - 2026-07-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,10 @@ release.
 ### Unreleased
 
 ### Added
-- Added `etsToSclkTicks()` API function and updated `writeCk()` to support web-enabled CK generation [#146](https://github.com/DOI-USGS/SpiceQL/pull/146)
+- Added `doubleEtsToSclkTicks()` API function to convert ephemeris times to encoded SCLK ticks [#146](https://github.com/DOI-USGS/SpiceQL/pull/146)
+
+### Changed
+- Changed `writeCk()` to now expect `times` as encoded SCLK ticks instead of ephemeris times and removed the `sclk` and `lsk` parameters. It no longer performs ET→SCLK conversion internally, so CK generation no longer requires local SCLK/LSK kernels as callers must now encode ticks themselves (see `doubleEtsToSclkTicks()`)[#146](https://github.com/DOI-USGS/SpiceQL/pull/146)
 
 ## 1.6.0 - 2026-07-13
 

--- a/SpiceQL/include/SpiceQL/api.h
+++ b/SpiceQL/include/SpiceQL/api.h
@@ -375,6 +375,38 @@ namespace SpiceQL {
         int limitCk=-1, 
         int limitSpk=1,
         std::vector<std::string> kernelList={});
+    
+    /**
+     * @brief Converts ephemeris times to encoded SCLK "ticks" (doubles)
+     *
+     * Given a spacecraft clock id, converts a vector of ephemeris times to the
+     * continuous encoded spacecraft clock values (ticks) produced by NAIF's
+     * sce2c_c. These are the values CK writers (e.g. ckw03_c) expect. Unlike
+     * doubleEtToSclk, which returns the human-readable clock string via sce2s_c,
+     * this returns the encoded double directly so callers can write CK segments
+     * without furnishing the SCLK/LSK themselves.
+     *
+     * @param frameCode int Spacecraft clock id (e.g. -74 for MRO)
+     * @param ets vector<double> ephemeris times to convert
+     * @param mission string Mission name as it relates to the config files
+     * @param useWeb bool Whether to run the conversion via the remote web service
+     * @param searchKernels bool Whether to search the kernels for the user
+     * @param fullKernelPath bool if true returns full kernel paths, default returns relative paths
+     * @param limitCk int number of cks to limit to, default is -1 to retrieve all
+     * @param limitSpk int number of spks to limit to, default is 1 to retrieve only one
+     * @param kernelList vector<string> vector of additional kernels to load
+     * @return vector<double> of encoded SCLK ticks matching the input ets
+     */
+    std::pair<std::vector<double>, nlohmann::json> etsToSclkTicks(
+        int frameCode,
+        std::vector<double> ets,
+        std::string mission="",
+        bool useWeb=false,
+        bool searchKernels=true,
+        bool fullKernelPath=false,
+        int limitCk=-1,
+        int limitSpk=1,
+        std::vector<std::string> kernelList={});
 
     /**
      * @brief Switch between NAIF frame string name to integer frame code

--- a/SpiceQL/include/SpiceQL/api.h
+++ b/SpiceQL/include/SpiceQL/api.h
@@ -527,7 +527,7 @@ namespace SpiceQL {
     **/
     std::pair<nlohmann::json, nlohmann::json> findMissionKeywords(
         std::string key, 
-        std::string mission="", 
+        std::string mission, 
         bool useWeb=false, 
         bool searchKernels=true, 
         bool fullKernelPath=false, 
@@ -555,7 +555,7 @@ namespace SpiceQL {
     **/
     std::pair<nlohmann::json, nlohmann::json> findTargetKeywords(
         std::string key, 
-        std::string mission="", 
+        std::string mission, 
         bool useWeb=false, 
         bool searchKernels=true, 
         bool fullKernelPath=false, 

--- a/SpiceQL/include/SpiceQL/api.h
+++ b/SpiceQL/include/SpiceQL/api.h
@@ -397,7 +397,7 @@ namespace SpiceQL {
      * @param kernelList vector<string> vector of additional kernels to load
      * @return vector<double> of encoded SCLK ticks matching the input ets
      */
-    std::pair<std::vector<double>, nlohmann::json> etsToSclkTicks(
+    std::pair<std::vector<double>, nlohmann::json> doubleEtsToSclkTicks(
         int frameCode,
         std::vector<double> ets,
         std::string mission="",

--- a/SpiceQL/include/SpiceQL/io.h
+++ b/SpiceQL/include/SpiceQL/io.h
@@ -163,9 +163,14 @@ namespace SpiceQL {
       * @param referenceFrame NAIF string for the reference frame the orientations are in
       * @param segmentId Some ID to give the segment
       * @param sclk path to S clock kernal to convert to and from ephemeris time
-      * @param lsk path to leap second kernal 
+      * @param lsk path to leap second kernel
       * @param angularVelocity optional, nx3 array of angular velocities
       * @param comment optional, comment to be associated with the segment
+      * @param timesAreTicks optional, if true the times are already encoded SCLK
+      *        ticks (as produced by sce2c_c / etsToSclkTicks) and no ET->SCLK
+      *        conversion is performed. In this mode the sclk and lsk kernels are
+      *        not furnished, allowing CK generation without a local SPICE data
+      *        directory (e.g. when the encoding was done via the web service).
       */
     void writeCk(std::string fileName,
                  std::vector<std::vector<double>> quats,
@@ -176,7 +181,8 @@ namespace SpiceQL {
                  std::string sclk,
                  std::string lsk,
                  std::vector<std::vector<double>> angularVelocity = {},
-                 std::string comment = "");
+                 std::string comment = "",
+                 bool timesAreTicks = false);
 
 
     /**

--- a/SpiceQL/include/SpiceQL/io.h
+++ b/SpiceQL/include/SpiceQL/io.h
@@ -158,19 +158,12 @@ namespace SpiceQL {
       *
       * @param fileName path to file to write the segment to
       * @param quats nx4 vector of orientations as quaternions
-      * @param times nx1 vector of times matching the number of quats
+      * @param times nx1 vector of encoded SCLK ticks
       * @param bodyCode NAIF body code identifying the orientations belong to
       * @param referenceFrame NAIF string for the reference frame the orientations are in
       * @param segmentId Some ID to give the segment
-      * @param sclk path to S clock kernal to convert to and from ephemeris time
-      * @param lsk path to leap second kernel
       * @param angularVelocity optional, nx3 array of angular velocities
       * @param comment optional, comment to be associated with the segment
-      * @param timesAreTicks optional, if true the times are already encoded SCLK
-      *        ticks (as produced by sce2c_c / etsToSclkTicks) and no ET->SCLK
-      *        conversion is performed. In this mode the sclk and lsk kernels are
-      *        not furnished, allowing CK generation without a local SPICE data
-      *        directory (e.g. when the encoding was done via the web service).
       */
     void writeCk(std::string fileName,
                  std::vector<std::vector<double>> quats,
@@ -178,26 +171,20 @@ namespace SpiceQL {
                  int bodyCode,
                  std::string referenceFrame,
                  std::string segmentId,
-                 std::string sclk,
-                 std::string lsk,
                  std::vector<std::vector<double>> angularVelocity = {},
-                 std::string comment = "",
-                 bool timesAreTicks = false);
+                 std::string comment = "");
 
 
     /**
      * @brief Write CK segments to a file
      *
      * Given orientations, angular velocities, times, target and reference frames, write data as a segment in a CK kernel.
+     * The segments' times must already be encoded SCLK ticks.
      *
      * @param fileName path to file to write the segment to
-     * @param sclk path to SCLK kernel matching the segments' frame code
-     * @param lsk path to LSK kernel
      * @param segments spkSegments to be writte
      */
   void writeCk(std::string fileName,
-               std::string sclk,
-               std::string lsk,
                std::vector<CkSegment> segments);
 
   void writeComment(std::string fileName,

--- a/SpiceQL/src/api.cpp
+++ b/SpiceQL/src/api.cpp
@@ -571,7 +571,7 @@ namespace SpiceQL {
     }
 
 
-   pair<string, json> doubleEtToSclk(int frameCode, double et, string mission, bool useWeb, bool searchKernels, bool fullKernelPath, int limitCk, int limitSpk, vector<string> kernelList) {
+    pair<string, json> doubleEtToSclk(int frameCode, double et, string mission, bool useWeb, bool searchKernels, bool fullKernelPath, int limitCk, int limitSpk, vector<string> kernelList) {
         SPDLOG_TRACE("calling doubleEtToSclk({}, {}, {}, {}, {}, {})", frameCode, et, mission, useWeb, searchKernels, kernelList.size());
 
         json ephemKernels;
@@ -613,7 +613,7 @@ namespace SpiceQL {
         SPDLOG_DEBUG("strsclktoet({}, {}, {}) -> {}", frameCode, mission, sclk, et);
 
         return make_pair(string(sclk), ephemKernels);
-   }
+    }
 
 
     pair<double, json> doubleSclkToEt(int frameCode, double sclk, string mission, bool useWeb, bool searchKernels, bool fullKernelPath, int limitCk, int limitSpk, vector<string> kernelList) {
@@ -761,6 +761,56 @@ namespace SpiceQL {
         }
 
         return {utc_string, lsks};
+    }
+
+
+    pair<vector<double>, json> etsToSclkTicks(int frameCode, vector<double> ets, string mission, bool useWeb, bool searchKernels, bool fullKernelPath, int limitCk, int limitSpk, vector<string> kernelList) {
+        SPDLOG_TRACE("calling etsToSclkTicks({}, {} ets, {}, {}, {}, {})", frameCode, ets.size(), mission, useWeb, searchKernels, kernelList.size());
+
+        json ephemKernels;
+
+        if (useWeb) {
+            json args = json::object({
+                {"frameCode", frameCode},
+                {"ets", ets},
+                {"mission", mission},
+                {"searchKernels", searchKernels},
+                {"fullKernelPath", fullKernelPath},
+                {"limitCk", limitCk},
+                {"limitSpk", limitSpk},
+                {"kernelList", kernelList}
+            });
+            json out = spiceAPIQuery("etsToSclkTicks", args);
+            vector<double> result = out["body"]["return"].get<vector<double>>();
+            return make_pair(result, out["body"]["kernels"]);
+        }
+
+        if (mission.empty()) mission = inferMission({}, {frameCode});
+
+        if (searchKernels) {
+            ephemKernels = Inventory::search_for_kernelsets({"base", mission}, {"fk", "lsk", "sclk"}, default_StartTime, default_StopTime, default_KernelQualities, default_KernelQualities, fullKernelPath, limitCk, limitSpk);
+        }
+
+        if (!kernelList.empty()) {
+            json regexk = Inventory::search_for_kernelset_from_regex(kernelList, fullKernelPath);
+            // merge them into the ephem kernels overwriting anything found in the query
+            merge_json(ephemKernels, regexk);
+        }
+
+        KernelSet sclkSet(ephemKernels);
+
+        vector<double> ticks;
+        ticks.reserve(ets.size());
+        for (double et : ets) {
+            double tick;
+            checkNaifErrors();
+            sce2c_c(frameCode, et, &tick);
+            checkNaifErrors();
+            ticks.push_back(tick);
+        }
+        SPDLOG_DEBUG("etsToSclkTicks({}, {}) -> {} ticks", frameCode, mission, ticks.size());
+
+        return make_pair(ticks, ephemKernels);
     }
 
 

--- a/SpiceQL/src/api.cpp
+++ b/SpiceQL/src/api.cpp
@@ -764,8 +764,8 @@ namespace SpiceQL {
     }
 
 
-    pair<vector<double>, json> etsToSclkTicks(int frameCode, vector<double> ets, string mission, bool useWeb, bool searchKernels, bool fullKernelPath, int limitCk, int limitSpk, vector<string> kernelList) {
-        SPDLOG_TRACE("calling etsToSclkTicks({}, {} ets, {}, {}, {}, {})", frameCode, ets.size(), mission, useWeb, searchKernels, kernelList.size());
+    pair<vector<double>, json> doubleEtsToSclkTicks(int frameCode, vector<double> ets, string mission, bool useWeb, bool searchKernels, bool fullKernelPath, int limitCk, int limitSpk, vector<string> kernelList) {
+        SPDLOG_TRACE("calling doubleEtsToSclkTicks({}, {} ets, {}, {}, {}, {})", frameCode, ets.size(), mission, useWeb, searchKernels, kernelList.size());
 
         json ephemKernels;
 
@@ -780,7 +780,7 @@ namespace SpiceQL {
                 {"limitSpk", limitSpk},
                 {"kernelList", kernelList}
             });
-            json out = spiceAPIQuery("etsToSclkTicks", args);
+            json out = spiceAPIQuery("doubleEtsToSclkTicks", args);
             vector<double> result = out["body"]["return"].get<vector<double>>();
             return make_pair(result, out["body"]["kernels"]);
         }
@@ -808,7 +808,7 @@ namespace SpiceQL {
             checkNaifErrors();
             ticks.push_back(tick);
         }
-        SPDLOG_DEBUG("etsToSclkTicks({}, {}) -> {} ticks", frameCode, mission, ticks.size());
+        SPDLOG_DEBUG("doubleEtsToSclkTicks({}, {}) -> {} ticks", frameCode, mission, ticks.size());
 
         return make_pair(ticks, ephemKernels);
     }

--- a/SpiceQL/src/io.cpp
+++ b/SpiceQL/src/io.cpp
@@ -89,28 +89,36 @@ namespace SpiceQL {
                string sclk,
                string lsk,
                vector<vector<double>> angularVelocities,
-               string comment) {
+               string comment,
+               bool timesAreTicks) {
 
     SpiceInt handle;
-    
-    // convert times, but first, we need SCLK+LSK kernels
 
-    // allow and furnish multiple sclks
-    std::vector<std::unique_ptr<Kernel>> sclkKernels;
-    if (!sclk.empty()) {
-      for (const std::string& sclkPath : split(sclk, ','))
-        sclkKernels.push_back(std::make_unique<Kernel>(sclkPath));
-    }
-    Kernel lskKernel(lsk);
-    
-    for(auto &et : times) {
-      double sclkdp;
+    // ckw03_c expects encoded SCLK ticks. When timesAreTicks is false we must
+    // convert the incoming ETs, which requires furnishing the SCLK+LSK kernels.
+    // When timesAreTicks is true the caller already encoded the times (e.g. via
+    // the web service), so we skip furnishing entirely -- this is what lets CK
+    // generation work without a local SPICE data directory.
+    if (!timesAreTicks) {
+      // convert times, but first, we need SCLK+LSK kernels
+
+      // allow and furnish multiple sclks
+      std::vector<std::unique_ptr<Kernel>> sclkKernels;
+      if (!sclk.empty()) {
+        for (const std::string& sclkPath : split(sclk, ','))
+          sclkKernels.push_back(std::make_unique<Kernel>(sclkPath));
+      }
+      Kernel lskKernel(lsk);
+
+      for(auto &et : times) {
+        double sclkdp;
+        checkNaifErrors();
+        sce2c_c(bodyCode/1000, et, &sclkdp);
+        checkNaifErrors();
+        et = sclkdp;
+      }
       checkNaifErrors();
-      sce2c_c(bodyCode/1000, et, &sclkdp);
-      checkNaifErrors();
-      et = sclkdp;
     }
-    checkNaifErrors();
 
     if(comment.empty()) {
       comment = "CK Kernel";

--- a/SpiceQL/src/io.cpp
+++ b/SpiceQL/src/io.cpp
@@ -86,39 +86,14 @@ namespace SpiceQL {
                int bodyCode,
                string referenceFrame,
                string segmentId,
-               string sclk,
-               string lsk,
                vector<vector<double>> angularVelocities,
-               string comment,
-               bool timesAreTicks) {
+               string comment) {
 
     SpiceInt handle;
 
-    // ckw03_c expects encoded SCLK ticks. When timesAreTicks is false we must
-    // convert the incoming ETs, which requires furnishing the SCLK+LSK kernels.
-    // When timesAreTicks is true the caller already encoded the times (e.g. via
-    // the web service), so we skip furnishing entirely -- this is what lets CK
-    // generation work without a local SPICE data directory.
-    if (!timesAreTicks) {
-      // convert times, but first, we need SCLK+LSK kernels
-
-      // allow and furnish multiple sclks
-      std::vector<std::unique_ptr<Kernel>> sclkKernels;
-      if (!sclk.empty()) {
-        for (const std::string& sclkPath : split(sclk, ','))
-          sclkKernels.push_back(std::make_unique<Kernel>(sclkPath));
-      }
-      Kernel lskKernel(lsk);
-
-      for(auto &et : times) {
-        double sclkdp;
-        checkNaifErrors();
-        sce2c_c(bodyCode/1000, et, &sclkdp);
-        checkNaifErrors();
-        et = sclkdp;
-      }
-      checkNaifErrors();
-    }
+    // ckw03_c expects encoded SCLK ticks. Callers must supply already-encoded
+    // ticks (e.g. from doubleEtsToSclkTicks), so no ET->SCLK conversion is done here
+    // and no SCLK/LSK kernels need to be furnished.
 
     if(comment.empty()) {
       comment = "CK Kernel";
@@ -266,7 +241,7 @@ namespace SpiceQL {
     return;
   }
 
-  void writeCk(string fileName, string sclk, string lsk, vector<CkSegment> segments) {
+  void writeCk(string fileName, vector<CkSegment> segments) {
 
     // TODO:
     //   write all segments not just first
@@ -282,8 +257,6 @@ namespace SpiceQL {
             segments[0].bodyCode,
             segments[0].referenceFrame,
             segments[0].segmentId,
-            sclk,
-            lsk,
             segments[0].angularVelocities,
             segments[0].comment);
 

--- a/SpiceQL/tests/Fixtures.cpp
+++ b/SpiceQL/tests/Fixtures.cpp
@@ -332,18 +332,20 @@ void LroKernelSet::SetUp() {
   ckPath1 = root / "ck" / "soc31_1111111_1111111_v21.bc";
   std::vector<std::vector<double>> avs = {{1,1,1}, {2,2,2}};
   std::vector<std::vector<double>> quats = {{0.2886751, 0.2886751, 0.5773503, 0.7071068 }, {0.4082483, 0.4082483, 0.8164966, 0 }};
-  // writeCk now expects encoded SCLK ticks. These are sce2c_c(-85, et) for the
-  // ETs {110000000, 120000000} and {130000000, 140000000} used previously.
-  std::vector<double> times1 = {5139381342423.142, 5794741342542.021};
-  std::vector<double> times2 = {6450101342365.975, 7105461342391.438};
+  // ETs used for the SPK segments below
+  std::vector<double> times1 = {110000000, 120000000};
+  std::vector<double> times2 = {130000000, 140000000};
+  // writeCk expects encoded SCLK ticks, sce2c_c(-85, et) of times1/times2
+  std::vector<double> ckTicks1 = {5139381342423.142, 5794741342542.021};
+  std::vector<double> ckTicks2 = {6450101342365.975, 7105461342391.438};
 
-  writeCk(ckPath1, quats, times1, bodyCode, referenceFrame, "CK ID 1", avs, "CK1");
+  writeCk(ckPath1, quats, ckTicks1, bodyCode, referenceFrame, "CK ID 1", avs, "CK1");
 
   // Write CK2 ------------------------------------------
   ckPath2 = root / "ck" / "lrolc_1111111_1111111_v11.bc";
   avs = {{3,4,5}, {6,5,5}};
   quats = {{0.3754439, 0.3754439, 0.3754439, -0.7596879}, {-0.5632779, -0.5632779, -0.5632779, 0.21944}};
-  writeCk(ckPath2, quats, times2, bodyCode, referenceFrame, "CK ID 2", avs, "CK2");
+  writeCk(ckPath2, quats, ckTicks2, bodyCode, referenceFrame, "CK ID 2", avs, "CK2");
 
   // Write SPK1 ------------------------------------------
   fs::create_directory(root / "spk");

--- a/SpiceQL/tests/Fixtures.cpp
+++ b/SpiceQL/tests/Fixtures.cpp
@@ -332,16 +332,18 @@ void LroKernelSet::SetUp() {
   ckPath1 = root / "ck" / "soc31_1111111_1111111_v21.bc";
   std::vector<std::vector<double>> avs = {{1,1,1}, {2,2,2}};
   std::vector<std::vector<double>> quats = {{0.2886751, 0.2886751, 0.5773503, 0.7071068 }, {0.4082483, 0.4082483, 0.8164966, 0 }};
-  std::vector<double> times1 = {110000000, 120000000};
-  std::vector<double> times2 = {130000000, 140000000};
+  // writeCk now expects encoded SCLK ticks. These are sce2c_c(-85, et) for the
+  // ETs {110000000, 120000000} and {130000000, 140000000} used previously.
+  std::vector<double> times1 = {5139381342423.142, 5794741342542.021};
+  std::vector<double> times2 = {6450101342365.975, 7105461342391.438};
 
-  writeCk(ckPath1, quats, times1, bodyCode, referenceFrame, "CK ID 1",  sclkPath, lskPath, avs, "CK1");
+  writeCk(ckPath1, quats, times1, bodyCode, referenceFrame, "CK ID 1", avs, "CK1");
 
   // Write CK2 ------------------------------------------
   ckPath2 = root / "ck" / "lrolc_1111111_1111111_v11.bc";
   avs = {{3,4,5}, {6,5,5}};
   quats = {{0.3754439, 0.3754439, 0.3754439, -0.7596879}, {-0.5632779, -0.5632779, -0.5632779, 0.21944}};
-  writeCk(ckPath2, quats, times2, bodyCode, referenceFrame, "CK ID 2", sclkPath, lskPath, avs, "CK2");
+  writeCk(ckPath2, quats, times2, bodyCode, referenceFrame, "CK ID 2", avs, "CK2");
 
   // Write SPK1 ------------------------------------------
   fs::create_directory(root / "spk");

--- a/SpiceQL/tests/IoTests.cpp
+++ b/SpiceQL/tests/IoTests.cpp
@@ -27,6 +27,23 @@ TEST_F(TempTestingFiles, UnitTestWriteCkTest) {
 }
 
 
+TEST_F(TempTestingFiles, UnitTestWriteCkTicksTest) {
+  fs::path path;
+  path = static_cast<fs::path>(getenv("SPICEROOT")) / "test_ck_ticks.bsp";
+
+  std::vector<std::vector<double>> orientations = {{0.2886751, 0.2886751, 0.5773503, 0.7071068 }, {0.4082483, 0.4082483, 0.8164966, 0 }};
+  std::vector<std::vector<double>> av = {{1,1,1}, {1,2,3}};
+  
+  // Already encoded ETS times as SCLK ticks so no sclk/lsk is needed
+  std::vector<double> ticks = {5139381342423.142, 5794741408078.021};
+  int bodyCode = -85000;
+  std::string referenceFrame = "j2000";
+  std::string segmentId = "CKCKCK";
+
+  writeCk(path, orientations, ticks, bodyCode, referenceFrame, segmentId, "", "", av, "", true);
+}
+
+
 
 TEST(IOTests, CreateSPKSegmentTest) {
   std::string comment = "This is a comment for \n a test SPK segment";

--- a/SpiceQL/tests/IoTests.cpp
+++ b/SpiceQL/tests/IoTests.cpp
@@ -13,34 +13,16 @@ TEST_F(TempTestingFiles, UnitTestWriteCkTest) {
   fs::path path;
   path = static_cast<fs::path>(getenv("SPICEROOT")) / "test_ck.bsp";
 
-  fs::path lskPath = fs::absolute("data/naif0012.tls"); 
-  fs::path sclkPath = fs::absolute("data/lro_clkcor_2020184_v00.tsc");
-
   std::vector<std::vector<double>> orientations = {{0.2886751, 0.2886751, 0.5773503, 0.7071068 }, {0.4082483, 0.4082483, 0.8164966, 0 }};
   std::vector<std::vector<double>> av = {{1,1,1}, {1,2,3}};
-  std::vector<double> times = {110000000, 120000001};
-  int bodyCode = -85000; 
-  std::string referenceFrame = "j2000";
-  std::string segmentId = "CKCKCK";
-
-  writeCk(path, orientations, times, bodyCode, referenceFrame, segmentId, sclkPath, lskPath, av);
-}
-
-
-TEST_F(TempTestingFiles, UnitTestWriteCkTicksTest) {
-  fs::path path;
-  path = static_cast<fs::path>(getenv("SPICEROOT")) / "test_ck_ticks.bsp";
-
-  std::vector<std::vector<double>> orientations = {{0.2886751, 0.2886751, 0.5773503, 0.7071068 }, {0.4082483, 0.4082483, 0.8164966, 0 }};
-  std::vector<std::vector<double>> av = {{1,1,1}, {1,2,3}};
-  
-  // Already encoded ETS times as SCLK ticks so no sclk/lsk is needed
+  // writeCk expects encoded SCLK ticks; these are sce2c_c(-85, et) for the ETs
+  // {110000000, 120000001}, so no sclk/lsk kernels are needed.
   std::vector<double> ticks = {5139381342423.142, 5794741408078.021};
   int bodyCode = -85000;
   std::string referenceFrame = "j2000";
   std::string segmentId = "CKCKCK";
 
-  writeCk(path, orientations, ticks, bodyCode, referenceFrame, segmentId, "", "", av, "", true);
+  writeCk(path, orientations, ticks, bodyCode, referenceFrame, segmentId, av);
 }
 
 

--- a/SpiceQL/tests/KernelTests.cpp
+++ b/SpiceQL/tests/KernelTests.cpp
@@ -130,6 +130,18 @@ TEST_F(LroKernelSet, UnitTestDoubleSclkToEt) {
 }
 
 
+TEST_F(LroKernelSet, UnitTestEtsToSclkTicks) {
+  nlohmann::json testKernelJson;
+  testKernelJson["kernels"] = {{ckPath1}, {ckPath2}, {spkPath1}, {spkPath2}, {spkPath3}, {ikPath2}, {fkPath}, {sclkPath}, {lskPath}};
+  KernelSet testSet(testKernelJson);
+
+  auto [ticks, kernels] = etsToSclkTicks(-85, {31593348.006268278}, "lro");
+
+  ASSERT_EQ(ticks.size(), 1);
+  EXPECT_NEAR(ticks[0], 922997380.174174, 1e-3);
+}
+
+
 TEST_F(LroKernelSet, UnitTestUtcToEt) {
   auto [et, kernels] = utcToEt("2016-11-26 22:32:14.582000");
 

--- a/SpiceQL/tests/KernelTests.cpp
+++ b/SpiceQL/tests/KernelTests.cpp
@@ -130,12 +130,12 @@ TEST_F(LroKernelSet, UnitTestDoubleSclkToEt) {
 }
 
 
-TEST_F(LroKernelSet, UnitTestEtsToSclkTicks) {
+TEST_F(LroKernelSet, UnitTestDoubleEtsToSclkTicks) {
   nlohmann::json testKernelJson;
   testKernelJson["kernels"] = {{ckPath1}, {ckPath2}, {spkPath1}, {spkPath2}, {spkPath3}, {ikPath2}, {fkPath}, {sclkPath}, {lskPath}};
   KernelSet testSet(testKernelJson);
 
-  auto [ticks, kernels] = etsToSclkTicks(-85, {31593348.006268278}, "lro");
+  auto [ticks, kernels] = doubleEtsToSclkTicks(-85, {31593348.006268278}, "lro");
 
   ASSERT_EQ(ticks.size(), 1);
   EXPECT_NEAR(ticks[0], 922997380.174174, 1e-3);

--- a/SpiceQL/tests/MemoTests.cpp
+++ b/SpiceQL/tests/MemoTests.cpp
@@ -54,12 +54,13 @@ TEST_F(TempTestingFiles, GetKernelTimes) {
 
   std::vector<std::vector<double>> orientations = {{0.2886751, 0.2886751, 0.5773503, 0.7071068 }, {0.4082483, 0.4082483, 0.8164966, 0 }};
   std::vector<std::vector<double>> av = {{1,1,1}, {1,2,3}};
-  std::vector<double> times = {110000000, 120000001};
-  int bodyCode = -85000; 
+  // Encoded SCLK ticks: sce2c_c(-85, et) for ETs {110000000, 120000001}.
+  std::vector<double> times = {5139381342423.142, 5794741408078.021};
+  int bodyCode = -85000;
   std::string referenceFrame = "j2000";
   std::string segmentId = "CKCKCK";
 
-  writeCk(path, orientations, times, bodyCode, referenceFrame, segmentId, sclkPath, lskPath, av);
+  writeCk(path, orientations, times, bodyCode, referenceFrame, segmentId, av);
 
   Kernel lsk(lskPath);
   Kernel sclk(sclkPath);

--- a/fastapi/app/main.py
+++ b/fastapi/app/main.py
@@ -330,6 +330,30 @@ async def doubleEtToSclk(
         body = ErrorModel(error=str(e))
         return ResponseModel(statusCode=500, body=body)
 
+
+@app.get("/etsToSclkTicks")
+async def etsToSclkTicks(
+    frameCode: Annotated[FrameCodeParam, Depends()],
+    ets: Annotated[EtsParam, Depends()],
+    mission: Annotated[MissionParam, Depends()],
+    commonParams: Annotated[CommonParams, Depends()]):
+    try:
+        result, kernels = pyspiceql.etsToSclkTicks(
+            frameCode.value,
+            ets.value,
+            mission.value,
+            False,
+            commonParams.searchKernels,
+            commonParams.fullKernelPath,
+            commonParams.limitCk,
+            commonParams.limitSpk,
+            commonParams.kernelList)
+        body = ResultModel(result=result, kernels=kernels)
+        return ResponseModel(statusCode=200, body=body)
+    except Exception as e:
+        body = ErrorModel(error=str(e))
+        return ResponseModel(statusCode=500, body=body)
+
 @app.get("/utcToEt")
 async def utcToEt(
     utc: Annotated[UtcParam, Depends()],

--- a/fastapi/app/main.py
+++ b/fastapi/app/main.py
@@ -483,7 +483,7 @@ async def getTargetFrameInfo(
 @app.get("/findMissionKeywords")
 async def findMissionKeywords(
     key: Annotated[KeyParam, Depends()],
-    mission: Annotated[MissionParam, Depends()],
+    mission: Annotated[MissionRequiredParam, Depends()],
     commonParams: Annotated[CommonParams, Depends()]):
     try:
         result, kernels = pyspiceql.findMissionKeywords(
@@ -504,7 +504,7 @@ async def findMissionKeywords(
 @app.get("/findTargetKeywords")
 async def findTargetKeywords(
     key: Annotated[KeyParam, Depends()],
-    mission: Annotated[MissionParam, Depends()],
+    mission: Annotated[MissionRequiredParam, Depends()],
     commonParams: Annotated[CommonParams, Depends()]):
     try:
         result, kernels = pyspiceql.findTargetKeywords(

--- a/fastapi/app/main.py
+++ b/fastapi/app/main.py
@@ -331,14 +331,14 @@ async def doubleEtToSclk(
         return ResponseModel(statusCode=500, body=body)
 
 
-@app.get("/etsToSclkTicks")
-async def etsToSclkTicks(
+@app.get("/doubleEtsToSclkTicks")
+async def doubleEtsToSclkTicks(
     frameCode: Annotated[FrameCodeParam, Depends()],
     ets: Annotated[EtsParam, Depends()],
     mission: Annotated[MissionParam, Depends()],
     commonParams: Annotated[CommonParams, Depends()]):
     try:
-        result, kernels = pyspiceql.etsToSclkTicks(
+        result, kernels = pyspiceql.doubleEtsToSclkTicks(
             frameCode.value,
             ets.value,
             mission.value,

--- a/fastapi/app/models.py
+++ b/fastapi/app/models.py
@@ -88,6 +88,8 @@ def to_list(value: Any) -> list:
     if value is not None:
         value = str(value)
         value = value.replace("[", "").replace("]", "").replace("\"", "").replace("\'", "").replace("\\", "").replace(" ", "").split(",")
+        # drop empty tokens so an empty input (e.g. [] -> "" -> ['']) yields [] instead of ['']
+        value = [v for v in value if v != ""]
     return value
 
 def verify_ets(data: dict) -> float:
@@ -571,6 +573,27 @@ class MissionParam():
                     }
                 }
             )] = ""):
+        self.value = mission
+
+
+class MissionRequiredParam():
+    @validate_params
+    def __init__(
+            self,
+            mission: Annotated[str, Query(
+                min_length=1,
+                description="Mission name. Required for this endpoint.",
+                openapi_examples={
+                    "ctx": {
+                        "summary": "MRO CTX",
+                        "value": "ctx"
+                    },
+                    "lro": {
+                        "summary": "LROC",
+                        "value": "lroc"
+                    }
+                }
+            )]):
         self.value = mission
 
 class NumRecordsParam():

--- a/fastapi/app/test_api_local.py
+++ b/fastapi/app/test_api_local.py
@@ -243,6 +243,28 @@ def test_doubleEtToSclk_returns_expected_sclk_string():
 
 
 # ---------------------------------------------------------------------------
+# etsToSclkTicks
+# ---------------------------------------------------------------------------
+
+def test_etsToSclkTicks_returns_expected_ticks():
+    expected_return = [922997380.174174, 922997394.174174]
+    lro_kernels = {
+        "fk": ["/lro/kernels/fk/lro_frames_2014049_v01.tf"],
+        "lsk": ["/base/kernels/lsk/naif0012.tls"],
+        "sclk": ["/lro/kernels/sclk/lro_clkcor_2024262_v00.tsc"],
+    }
+    with patch("pyspiceql.etsToSclkTicks", return_value=(expected_return, lro_kernels)):
+        response = client.get("/etsToSclkTicks", params={
+            "frameCode": -85,
+            "ets": "[31593348.006268278,31593362.006268278]",
+            "mission": "lro",
+            "searchKernels": "true",
+        })
+    assert response.status_code == 200
+    assert response.json()["body"]["return"] == expected_return
+
+
+# ---------------------------------------------------------------------------
 # utcToEt
 # ---------------------------------------------------------------------------
 

--- a/fastapi/app/test_api_local.py
+++ b/fastapi/app/test_api_local.py
@@ -243,18 +243,18 @@ def test_doubleEtToSclk_returns_expected_sclk_string():
 
 
 # ---------------------------------------------------------------------------
-# etsToSclkTicks
+# doubleEtsToSclkTicks
 # ---------------------------------------------------------------------------
 
-def test_etsToSclkTicks_returns_expected_ticks():
+def test_doubleEtsToSclkTicks_returns_expected_ticks():
     expected_return = [922997380.174174, 922997394.174174]
     lro_kernels = {
         "fk": ["/lro/kernels/fk/lro_frames_2014049_v01.tf"],
         "lsk": ["/base/kernels/lsk/naif0012.tls"],
         "sclk": ["/lro/kernels/sclk/lro_clkcor_2024262_v00.tsc"],
     }
-    with patch("pyspiceql.etsToSclkTicks", return_value=(expected_return, lro_kernels)):
-        response = client.get("/etsToSclkTicks", params={
+    with patch("pyspiceql.doubleEtsToSclkTicks", return_value=(expected_return, lro_kernels)):
+        response = client.get("/doubleEtsToSclkTicks", params={
             "frameCode": -85,
             "ets": "[31593348.006268278,31593362.006268278]",
             "mission": "lro",

--- a/fastapi/app/test_api_remote.py
+++ b/fastapi/app/test_api_remote.py
@@ -472,6 +472,48 @@ class TestDoubleEtToSclk:
 
 
 # ---------------------------------------------------------------------------
+# etsToSclkTicks
+# ---------------------------------------------------------------------------
+
+class TestEtsToSclkTicks:
+    """
+    curl -XGET "https://astrogeology.usgs.gov/apis/spiceql/latest/etsToSclkTicks
+        ?frameCode=-85&ets=[31593348.006268278]&mission=lro&searchKernels=true"
+    """
+
+    ENDPOINT = f"{BASE_URL}/etsToSclkTicks"
+    PARAMS = {
+        "frameCode": -85,
+        "ets": "[31593348.006268278]",
+        "mission": "lro",
+        "searchKernels": "true",
+    }
+
+    def test_status_ok(self):
+        r = httpx.get(self.ENDPOINT, params=self.PARAMS)
+        assert_success(r)
+
+    def test_returns_one_tick(self):
+        r = httpx.get(self.ENDPOINT, params=self.PARAMS)
+        body = assert_success(r)
+        result = body["return"]
+        assert isinstance(result, list)
+        assert len(result) == 1, "Expected one tick per input ET"
+
+    def test_tick_value(self):
+        r = httpx.get(self.ENDPOINT, params=self.PARAMS)
+        body = assert_success(r)
+        assert approx_equal(body["return"][0], 922997380.174174), (
+            f"Expected ~922997380.174174, got {body['return'][0]}"
+        )
+
+    def test_kernels_include_sclk(self):
+        r = httpx.get(self.ENDPOINT, params=self.PARAMS)
+        body = assert_success(r)
+        assert "sclk" in body["kernels"]
+
+
+# ---------------------------------------------------------------------------
 # utcToEt
 # ---------------------------------------------------------------------------
 

--- a/fastapi/app/test_api_remote.py
+++ b/fastapi/app/test_api_remote.py
@@ -472,16 +472,16 @@ class TestDoubleEtToSclk:
 
 
 # ---------------------------------------------------------------------------
-# etsToSclkTicks
+# doubleEtsToSclkTicks
 # ---------------------------------------------------------------------------
 
-class TestEtsToSclkTicks:
+class TestDoubleEtsToSclkTicks:
     """
-    curl -XGET "https://astrogeology.usgs.gov/apis/spiceql/latest/etsToSclkTicks
+    curl -XGET "https://astrogeology.usgs.gov/apis/spiceql/latest/doubleEtsToSclkTicks
         ?frameCode=-85&ets=[31593348.006268278]&mission=lro&searchKernels=true"
     """
 
-    ENDPOINT = f"{BASE_URL}/etsToSclkTicks"
+    ENDPOINT = f"{BASE_URL}/doubleEtsToSclkTicks"
     PARAMS = {
         "frameCode": -85,
         "ets": "[31593348.006268278]",


### PR DESCRIPTION
Adds an `etsToSclkTicks` API function (exposed via pyspiceql and a new REST endpoint) that encodes ephemeris times to SCLK ticks, and adds a `timesAreTicks` flag to `writeCk` that skips the ET→SCLK conversion and SCLK/LSK furnish. This lets ALE's `isd_to_kernel` generate CKs using web SpiceQL, without a local SPICE data directory.

Added changes:
- Required `mission` param for `findMissionKeywords` and `findTargetKeywords`
- Drop empty tokens in `to_list()` output

Related [ALE PR](https://github.com/DOI-USGS/ale/pull/733) that uses `etsToSclkTicks`

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

